### PR TITLE
chore: add missing project infrastructure (CI, templates, .gitignore)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug to help us improve OpenGUI
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of OpenGUI is affected?
+      options:
+        - Server (Backend)
+        - Android Client
+        - Both
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: OpenGUI version or commit hash.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Please copy and paste any relevant log output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature Request
+description: Suggest an idea for OpenGUI
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a feature!
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Is your feature request related to a problem? Please describe.
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part would this feature affect?
+      options:
+        - Server (Backend)
+        - Android Client
+        - Both
+        - Documentation
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Description
+
+<!-- Provide a brief description of the changes in this PR -->
+
+## Type of Change
+
+<!-- Check the relevant box(es) -->
+
+- [ ] 🐛 Bug fix
+- [ ] ✨ New feature
+- [ ] 🔧 Refactor
+- [ ] 📝 Documentation update
+- [ ] 🧪 Test update
+- [ ] 🔨 Chore
+
+## Related Issue
+
+<!-- Link the related issue, e.g., Fixes #123 -->
+
+Fixes #
+
+## Checklist
+
+- [ ] I have followed the project's code style (run `pnpm format-and-lint:fix`)
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the documentation accordingly
+- [ ] I have run the server locally and verified the changes work
+- [ ] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,88 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: server/pnpm-lock.yaml
+      - run: cd server && pnpm install --frozen-lockfile
+      - run: cd server && pnpm format-and-lint
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: server/pnpm-lock.yaml
+      - run: cd server && pnpm install --frozen-lockfile
+      - run: cd server/packages/database && pnpm prisma generate
+      - run: cd server && pnpm build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: lint
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: opengui
+          POSTGRES_PASSWORD: opengui
+          POSTGRES_DB: opengui
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - "6379:6379"
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: server/pnpm-lock.yaml
+      - run: cd server && pnpm install --frozen-lockfile
+      - run: cd server/packages/database && pnpm prisma generate
+      - run: cd server/apps/backend && pnpm test
+        env:
+          DATABASE_URL: postgresql://opengui:opengui@localhost:5432/opengui
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# OS
+.DS_Store
+Thumbs.db
+*.log
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Node
+node_modules/
+.pnp
+.pnp.js
+
+# Build
+dist/
+build/
+.next/
+*.tsbuildinfo
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# Misc
+*.tgz
+*.tar.gz
+coverage/
+.nyc_output/


### PR DESCRIPTION
## Summary
- **Add root `.gitignore`** — covers OS files (`.DS_Store`), IDE configs (`.idea/`, `.vscode/`), Node build artifacts (`dist/`, `node_modules/`), and environment files (`.env*`)
- **Add GitHub Actions CI workflow** (`.github/workflows/ci.yml`) — three jobs: lint/format, typecheck/build, and unit tests with PostgreSQL + Redis service containers
- **Add Issue templates** — `bug_report.yml` and `feature_request.yml` with structured forms for component selection and reproduction steps
- **Add PR template** — `.github/PULL_REQUEST_TEMPLATE.md` with change type checklist and conventional commit reminder

## Context
Project review (ISS-115) identified these as the highest-priority gaps:
1. No CI/CD — no automated lint, typecheck, or test verification on PRs
2. No issue/PR templates — high friction for community contributions
3. No root `.gitignore` — OS/IDE files not globally ignored

## Test plan
- [ ] CI workflow triggers on push/PR to `main`
- [ ] Lint job runs `pnpm format-and-lint` in the `server/` monorepo
- [ ] Typecheck job runs `pnpm build` (includes Prisma generate)
- [ ] Test job runs `pnpm test` with PostgreSQL + Redis service containers
- [ ] New issue creation shows structured template picker
- [ ] New PR creation shows checklist template

🤖 Generated via BusyDog Desktop collaboration task