### PR TITLE
[codex] Translate code comments to English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,5 @@ Rules:
 - Repository-level architecture notes, public-release boundaries, allowed change scope, and validation requirements are defined by `CLAUDE.md`.
 - If `README`, old comments, historical docs, or this file conflict with `CLAUDE.md`, follow `CLAUDE.md`.
 - If a subdirectory adds its own `CLAUDE.md` later, it may only add implementation details for that subtree; repository-level rules still come from the root `CLAUDE.md`.
+- For source-available public-release work, keep code comments, KDoc/JSDoc, and test `describe` / `it` names in English.
+- Chinese and other localized text may remain in localized docs, user-visible product copy, real-app UI matching strings, mock/sample data, and other runtime content where the language is part of the behavior.

--- a/client/automation/src/main/java/com/coremate/opengui/automation/AMServiceManager.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/AMServiceManager.kt
@@ -26,38 +26,38 @@ import com.coremate.opengui.automation.biz.permission.AMPermissionDialog
 class AMServiceManager {
 
     companion object {
-        ///全局上下文
+        ///Global Context
         lateinit var applicationContext: Context
         val instance by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
             AMServiceManager()
         }
     }
 
-    //是否开启前台服务
+    //Whether foreground service is enabled
     private var isStartService = false
 
-    //前台服务图标
+    //Foreground service icon
     var notificationImg: Int? = null
 
 //    var cozeAIManager: CozeAIManager? = null
 
     /**
-     * 初始化
-     * @param context 必须是ApplicationContext
+ * Initialize
+ * @param context must be Application Context
      */
     fun init(context: Context) {
         applicationContext = context
     }
 
     /**
-     * 获取无障碍服务
+ * Get Accessibility service
      */
     fun accessibilityService(): AccessibilityService? {
         return SelectToSpeakService.service
     }
 
     /**
-     * 检测权限
+ * Check Permission
      * */
     fun checkPermission(
         context: Activity,
@@ -77,12 +77,12 @@ class AMServiceManager {
     }
 
     /**
-     * 开启前台服务
-     * @param notificationImg 图标
+ * Start foreground service
+ * @param notification Img icon
      */
     fun startForegroundService(context: Activity, requestCode: Int, notificationImg: Int? = null) {
         this.notificationImg = notificationImg
-        //请求通知权限
+        //Request notification permission
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             if (context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 context.requestPermissions(
@@ -99,7 +99,7 @@ class AMServiceManager {
 
     private fun startForeground(context: Activity) {
         isStartService = true
-        //再次启动Service
+        //Start Service again
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val intentFive = Intent(context, AMForegroundService::class.java)
             context.startForegroundService(intentFive)
@@ -110,10 +110,10 @@ class AMServiceManager {
     }
 
     /**
-     * 关闭前台服务
+ * Stop foreground service
      */
     fun stopForegroundService(context: Context?) {
-        //停止Service
+        //Stop Service
         if (context != null) {
             if (isStartService) {
                 isStartService = false
@@ -131,7 +131,7 @@ class AMServiceManager {
     }
 
     /**
-     * 开启自启动权限
+ * Open autostart permission settings
      */
     fun gotoOppoAutoStartSettings(context: Context) {
         AlertDialog.Builder(context)
@@ -156,7 +156,7 @@ class AMServiceManager {
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                         context.startActivity(intent)
                     } catch (e: Exception) {
-                        // fallback：跳转到应用详情页
+                        // fallback: navigate to the app details page
                         val fallbackIntent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
                         fallbackIntent.data = Uri.parse("package:${context.packageName}")
                         fallbackIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
@@ -172,9 +172,9 @@ class AMServiceManager {
     }
 
     /**
-     * 执行任务
-     * @param context 当前调用的actviity
-     * @param param - bizType 和 对应的bean(参数)
+ * Execute task
+ * @param context current calling activity
+ * @param param biz Type and the corresponding parameter bean
      */
     fun processTask(context: Activity, param: AMDataContainer) {
         AMCore.instance.context = context
@@ -190,21 +190,21 @@ class AMServiceManager {
     }
 
     /**
-     * 添加任务监听
+ * Add task listener
      * */
     fun addObserver(listener: IAMProcessListener) {
         AMCore.instance.addObserver(listener)
     }
 
     /**
-     * 移除任务监听
+ * Remove task listener
      * */
     fun removeObserver(listener: IAMProcessListener) {
         AMCore.instance.removeObserver(listener)
     }
 
     /**
-     * 移除所有监听
+ * Remove all listeners
      * */
     fun removeAllObserver() {
         AMCore.instance.removeAllObserver()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/AMCore.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/AMCore.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.KClass
 internal class AMCore : IAMProcessListener {
 
     companion object {
-        //跳转到权限页面之前的activity
+        //Activity before navigating to the permission page
         @JvmStatic
         @SuppressLint("StaticFieldLeak")
         var activityByOp: Activity? = null
@@ -44,11 +44,11 @@ internal class AMCore : IAMProcessListener {
 
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    ///待执行的（目前只存自动回复的任务）
+    ///Pending tasks; currently only auto-reply tasks are stored
     var waitTasks = mutableListOf<AMDataContainer>()
 
     /**
-     * 添加任务监听
+ * Add task listener
      * */
     fun addObserver(listener: IAMProcessListener) {
         synchronized(this) {
@@ -57,7 +57,7 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 移除任务监听
+ * Remove task listener
      * */
     fun removeObserver(listener: IAMProcessListener) {
         synchronized(this) {
@@ -66,7 +66,7 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 移除所有监听
+ * Remove all listeners
      * */
     fun removeAllObserver() {
         synchronized(this) {
@@ -76,11 +76,11 @@ internal class AMCore : IAMProcessListener {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                      核心调度
+    // Core scheduler
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    ///消费
+    ///Consume
     fun consume() {
         if (amContext?.taskManager?.isStartTool == true) {
             return
@@ -88,7 +88,7 @@ internal class AMCore : IAMProcessListener {
         if (waitTasks.isNotEmpty()) {
             val param = waitTasks.first()
             waitTasks.removeAt(0)
-            ///前置consume()操作
+            ///Pre-consume operation
             when (param.bizType) {
                 AMTaskBizType.TK_PUBLISH_VIDEO_MIX -> {
                     val clipboard =
@@ -138,7 +138,7 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 开始调度
+ * Start scheduling
      * */
     @JvmOverloads
     fun executes(
@@ -148,9 +148,9 @@ internal class AMCore : IAMProcessListener {
         threadFactory: ThreadFactory,
         data: AMDataContainer? = null,
     ) {
-        //先释放，防止之前的任务相关还存在
+        //Release first to clear any leftover task state
         destroyAll()
-        //设置上下文执行操作
+        //Set up context execution operations
         amContext = AMContext(
             activity = context,
             targetApps = targetApps,
@@ -162,20 +162,20 @@ internal class AMCore : IAMProcessListener {
         }.apply {
             taskManager.isStartTool = true
         }
-        //判断是否在app内
+        //Check whether inside the app
         if (AMContext.isInTargetApp) {
             Handler(Looper.getMainLooper()).post {
                 targetApps.first().openThirdApp()
-                //执行任务
+                //Execute task
                 AMLog.onEDebugLog("开始执行任务")
                 amContext?.taskManager?.onExecute(taskCls, data)
             }
         } else {
             targetApps.first().openThirdApp()
             Handler(Looper.getMainLooper()).postDelayed({
-                //强制在目标app内
+                //Force execution inside the target app
                 AMContext.isInTargetApp = true
-                //执行任务
+                //Execute task
                 AMLog.onEDebugLog("进入目标app后,开始执行任务")
                 amContext?.taskManager?.onExecute(taskCls, data)
             }, 850)
@@ -184,26 +184,26 @@ internal class AMCore : IAMProcessListener {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                      服务检测
+    // Service check
     //
     /////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * 辅助监测
+ * Helper monitoring
      * */
     fun onAccessibilityEvent(event: AccessibilityEvent) {
-        //过滤当前app的包名
+        //Filter the current app package name
         val packageName = AMServiceManager.applicationContext.packageName ?: ""
         if (event.packageName == packageName) {
             AMContext.isInTargetApp = false
             return
         }
-        //开始检测执行
+        //Start check execution
         amContext?.checkTargetAndDispatchTaskManager(event)
     }
 
     /**
-     * 服务中断
+ * Service interruption
      * */
     fun onAccessibilityInterrupt() {
         if (amContext?.taskManager?.taskState == AMTaskState.STOP) {
@@ -211,7 +211,7 @@ internal class AMCore : IAMProcessListener {
                 "无障碍服务中断，但是任务已经结束",
             )
         } else {
-            //打印记录
+            //Print records
             AMLog.onEDebugLog(
                 "无障碍服务中断",
             )
@@ -223,12 +223,12 @@ internal class AMCore : IAMProcessListener {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                      整体流程状态回调 IAMProcessListener
+    // Overall process status callback IAM Process Listener
     //
     /////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * 任务开始
+ * Task started
      * */
     override fun onProcessTaskStart() {
         amContext?.taskManager?.setTaskResume = true
@@ -241,7 +241,7 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 任务暂停
+ * Task paused
      * */
     override fun onProcessTaskPause(isActive: Boolean) {
         amContext?.taskManager?.setTaskState(AMTaskState.PAUSE)
@@ -253,7 +253,7 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 任务恢复
+ * Task resumed
      * */
     override fun onProcessTaskResume() {
         amContext?.taskManager?.setTaskState(AMTaskState.RESUME)
@@ -265,11 +265,11 @@ internal class AMCore : IAMProcessListener {
     }
 
     /**
-     * 任务成功完成
-     * @param isSuccess 是否成功
-     * @param elapsedTime 耗时
-     * @param data 完成后的数据
-     * @param exception 异常
+ * Task completed successfully
+ * @param is Success whether execution succeeded
+ * @param elapsed Time elapsed time
+ * @param data data after completion
+ * @param exception exception
      * */
     override fun onProcessTaskFinish(
         isSuccess: Boolean,
@@ -279,12 +279,12 @@ internal class AMCore : IAMProcessListener {
     ) {
         synchronized(this) {
             AMLog.onEDebugLog("onProcessTaskFinish")
-            //任务结束 (完成之后，不用在抛出停止异常)
+            //Task ended; after completion, no need to throw a stop exception
             amContext?.taskManager?.setTaskState(AMTaskState.STOP)
             mainHandler.post {
-                //关闭核心功能
+                //Close core functionality
                 amContext?.taskManager?.isStartTool = false
-                //任务释放
+                //Release task resources
                 amContext?.destroyCompsAndTask()
                 listeners.forEach {
                     it.onProcessTaskFinish(isSuccess, elapsedTime, exception, sucData)
@@ -297,7 +297,7 @@ internal class AMCore : IAMProcessListener {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                      释放所有
+    // Release all resources
     //
     /////////////////////////////////////////////////////////////////////////////////
 
@@ -308,7 +308,7 @@ internal class AMCore : IAMProcessListener {
         }
     }
 
-    //异常监听
+    //Exception listener
     private inner class ATThreadFactory :
         ThreadFactory {
         override fun newThread(r: Runnable?): Thread {
@@ -318,7 +318,7 @@ internal class AMCore : IAMProcessListener {
                     if (e is AMTaskException) {
                         when (e.reason) {
                             AMTaskErrorReason.PAUSE -> {
-                                //... 暂停不处理
+                                //... Pause is not handled
                             }
 
                             AMTaskErrorReason.STOP -> {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/AMTargetApp.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/AMTargetApp.kt
@@ -6,11 +6,11 @@ import android.content.pm.PackageManager
 import com.coremate.opengui.automation.AMServiceManager
 
 /**
- * 目标APP
- * @param zhName app名称
- * @param shortName 简称（例如微信 WX）
- * @param packageName 包名
- * @param version 适配版本
+ * Target app
+ * @param zh Name app name
+ * @param short Name short name, such as We Chat WX
+ * @param package Name package name
+ * @param version compatible version
  * */
 enum class AMTargetApp(
     val zhName: String,
@@ -57,16 +57,16 @@ enum class AMTargetApp(
 
     companion object {
         /**
-         * 判断是否安装
+ * Check whether installed
          * */
         fun checkInstall(context: Context, targetApp: AMTargetApp): Boolean =
             isAppInstalled(context, targetApp.packageName)
 
         /**
-         * 判断三方app是否已安装
-         * @param context 上下文对象
-         * @param packageName 三方app的包名
-         * @return 是否已安装
+ * Check whether the third-party app is installed
+ * @param context Context Object
+ * @param package Name third-partyapp Package name
+ * @return whether installed
          */
         private fun isAppInstalled(context: Context, packageName: String?): Boolean {
             val packageManager = context.packageManager
@@ -80,7 +80,7 @@ enum class AMTargetApp(
     }
 
     /**
-     * 打开三方app
+ * Open third-party app
      * */
     fun openThirdApp() {
         val intent =

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMBaseFloatWindow.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMBaseFloatWindow.kt
@@ -16,13 +16,13 @@ import com.coremate.opengui.automation.base.data.AMDataContainer
 import com.coremate.opengui.automation.base.utils.AMUtils
 
 /**
- * 悬浮窗
+ * Floating window
  * */
 abstract class AMBaseFloatWindow<BD : ViewBinding, SD : AMCompRepository>(context: Context) :
     FrameLayout(context),
     IAMComponent {
 
-    //悬浮属性
+    //Floating attributes
     val windowParams: WindowManager.LayoutParams by lazy {
         val type: Int = if (Build.VERSION.SDK_INT < 24) {
             WindowManager.LayoutParams.TYPE_PHONE
@@ -38,28 +38,28 @@ abstract class AMBaseFloatWindow<BD : ViewBinding, SD : AMCompRepository>(contex
         params
     }
 
-    //当前悬浮tags类型
+    //Current floating tags type
     var curWindowTags: Int? = null
 
     private var interactTranslationX = 0f
     private var interactTranslationY = 0f
 
-    //当前模型
+    //Current model
     internal lateinit var curModel: AMCompModel
 
-    //上下文
+    //Context
     internal lateinit var amContext: AMContext
 
     protected var binding: BD
     protected var repository: SD
 
-    //对外事件接口
+    //External event interface
     internal var listener: IAMCompEventListener? = null
 
     init {
         binding = this.setBinding()
         repository = AMUtils.getT(this, 1) as SD
-        //初始化坐标
+        //Initial coordinates
         interactTranslationX = repository.startX.toFloat()
         interactTranslationY = repository.startY.toFloat()
         repository.wpX = interactTranslationX.toInt()
@@ -76,7 +76,7 @@ abstract class AMBaseFloatWindow<BD : ViewBinding, SD : AMCompRepository>(contex
     }
 
     /**
-     * 拖动效果
+ * Drag behavior
      * */
     open fun setDragMoveSelf() {
         if (openDragMove()) {
@@ -133,7 +133,7 @@ abstract class AMBaseFloatWindow<BD : ViewBinding, SD : AMCompRepository>(contex
     }
 
     /**
-     * 隐藏
+ * Hide
      * */
     @CallSuper
     override fun dismiss() {
@@ -148,7 +148,7 @@ abstract class AMBaseFloatWindow<BD : ViewBinding, SD : AMCompRepository>(contex
     }
 
     /**
-     * 销毁
+ * Destroy
      * */
     open fun onDestroy() {
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMCompRepository.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMCompRepository.kt
@@ -4,11 +4,11 @@ import com.coremate.opengui.automation.base.context.AMContext
 
 open class AMCompRepository {
 
-    //初始坐标
+    //Initial coordinates
     open var startX = 0
     open var startY = 0
 
-    //悬浮窗的坐标记录
+    //Floating-window coordinate record
     var wpX = 0
     var wpY = 0
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMWindowManager.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/AMWindowManager.kt
@@ -50,7 +50,7 @@ internal class AMWindowManager : IAMSubManagerLifeCycle {
 
 
     /**
-     * 添加view
+ * Add view
      * */
     fun add(
         component: AMBaseFloatWindow<*, *>,
@@ -82,7 +82,7 @@ internal class AMWindowManager : IAMSubManagerLifeCycle {
     }
 
     /**
-     * 移除view
+ * Remove view
      * */
     fun remove(component: AMBaseFloatWindow<*, *>) {
         if (component.parent != null) {
@@ -91,7 +91,7 @@ internal class AMWindowManager : IAMSubManagerLifeCycle {
     }
 
     /**
-     * 是否事件穿透
+ * Whether events pass through
      * */
     fun changeEventStrike(component: AMBaseFloatWindow<*, *>?, isStrike: Boolean) {
         component?.let {
@@ -105,7 +105,7 @@ internal class AMWindowManager : IAMSubManagerLifeCycle {
     }
 
     /**
-     * 更改view的位置
+ * Change view position
      * */
     fun updateView(component: AMBaseFloatWindow<*, *>) {
         mWindowManager?.updateViewLayout(component, component.windowParams)
@@ -118,7 +118,7 @@ internal class AMWindowManager : IAMSubManagerLifeCycle {
     /////////////////////////////////////////////////////////////////////////////////
 
     /**
-     * toast 提示
+ * Toast prompt
      * */
     fun showToast(msg: String) {
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/IAMComponent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/IAMComponent.kt
@@ -6,22 +6,22 @@ import com.coremate.opengui.automation.base.data.AMDataContainer
 internal interface IAMComponent {
 
     /**
-     * 初始化
+ * Initialize
      * */
     fun initUIAndData(dataContainer: AMDataContainer?)
 
     /**
-     * 显示
+ * Show
      * */
     fun show()
 
     /**
-     * 隐藏
+ * Hide
      * */
     fun dismiss()
 
     /**
-     * 设置隐藏自身
+ * Set self-hidden state
      * */
     fun setHiddenSelf()
 }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/factory/AMCompModel.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/factory/AMCompModel.kt
@@ -4,17 +4,17 @@ import com.coremate.opengui.automation.base.component.IAMComponent
 import kotlin.reflect.KClass
 
 /**
- * 组件模型
+ * Component model
  * */
 internal class AMCompModel(val compCls: KClass<*>) {
 
-    //组件实例
+    //Component instance
     var component: IAMComponent? = null
 
-    //显示隐藏
+    //Show Hide
     private var isShow: Boolean = false
 
-    //是否隐藏了自身(标识)
+    //Whether it hid itself (marker)
     private var isHiddenSelf = false
 
     fun changeShow(show: Boolean) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/factory/IAMUIFactory.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/factory/IAMUIFactory.kt
@@ -17,15 +17,15 @@ internal class AMFloatFactory {
         listener: IAMCompEventListener?
     ): IAMComponent = (model.compCls.constructors.first()
         .call(AMServiceManager.applicationContext) as AMBaseFloatWindow<*, *>).apply {
-        //设置初始化数据
+        //Set initial data
         this.curModel = model
         this.amContext = amContext
         this.listener = listener
     }.apply {
-        //设置拖动效果
+        //Set drag behavior
         setDragMoveSelf()
     }.apply {
-        //开始加载UI和数据
+        //Start loading UI and data
         initUIAndData(dataContainer)
     }
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/manager/AMCompManager.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/manager/AMCompManager.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.base.utils.AMUtils
 internal class AMCompManager(private val amContext: AMContext) :
     IAMCompEventListener, IAMCompForeBackObserver {
 
-    //组件栈
+    //Component stack
     private val componentStack = mutableListOf<AMCompModel>()
 
     fun onExecute(
@@ -31,10 +31,10 @@ internal class AMCompManager(private val amContext: AMContext) :
     }
 
     /**
-     * 显示组件
-     * @param targetModel 目标组件模型
-     * @param isShow 是否直接显示出来
-     * @param dataContainer 数据
+ * Show Component
+ * @param target Model Target Component model
+ * @param isShow whether to show immediately
+ * @param data Container data
      * */
     private fun showComponent(
         targetModel: AMCompModel,
@@ -52,7 +52,7 @@ internal class AMCompManager(private val amContext: AMContext) :
         })
     }
 
-    //获取所有组件
+    //Get all components
     fun allComponent(): MutableList<AMCompModel> {
         return componentStack
     }
@@ -78,7 +78,7 @@ internal class AMCompManager(private val amContext: AMContext) :
     }
 
     /**
-     * 返回app
+ * Return to app
      * */
     override fun onBackApp() {
         AMUtils.jumpToPageInApp(
@@ -93,7 +93,7 @@ internal class AMCompManager(private val amContext: AMContext) :
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //进入目标app前台（判断显示悬浮组件）
+    //Enter target app foreground and decide whether to show floating components
     override fun onBecameForegroundInTargetApp() {
         if (componentStack.isNotEmpty() && amContext.taskManager.isStartTool) {
             componentStack.forEach {
@@ -104,13 +104,13 @@ internal class AMCompManager(private val amContext: AMContext) :
         }
     }
 
-    //进入目标后台
+    //Enter target background
     override fun onBecameBackgroundInTargetApp() {
         //....
     }
 
     fun onDestroy() {
-        //隐藏所有
+        //Hide all
         componentStack.forEach {
             if (it.component != null) {
                 it.component?.dismiss()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/component/manager/IAMCompEventListener.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/component/manager/IAMCompEventListener.kt
@@ -2,16 +2,16 @@ package com.coremate.opengui.automation.base.component.manager
 
 internal interface IAMCompEventListener {
 
-    //开始
+    //Start
     fun onStartComp()
 
-    //暂停
+    //Pause
     fun onPauseComp()
 
-    //结束
+    //End
     fun onStopComp()
 
-    //返回app
+    //Return to app
     fun onBackApp()
 
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/context/AMCheckTargetApp.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/context/AMCheckTargetApp.kt
@@ -9,7 +9,7 @@ import com.coremate.opengui.automation.base.utils.AMLog
 import java.util.*
 
 /**
- * 检测是否在目标内
+ * Checkwhetherin Targetinside
  * */
 internal class AMCheckTargetApp(
     var amContext: AMContext,
@@ -21,22 +21,22 @@ internal class AMCheckTargetApp(
     private var mCheckTimer: Timer? = null
     private var mCheckTimerTask: BroadcastTimerTask? = null
 
-    //延时检测时间
+    //Delayed check time
     private val mCheckDelayTime: Long = 500
 
-    //倒计时间隔
+    //Countdowninterval
     private val mCheckCtTime: Long = 800
 
-    //检测次数
+    //Checkcount
     private var mCheckCount = 3
 
-    //临时计数
+    //Temporary count
     private var mTmpCount = 0
 
     /**
-     * 检测是否在目标app
-     * @param event 事件
-     * @param reCheck 是否需要进行重新检测
+ * Checkwhetherin Targetapp
+ * @param event event
+ * @param reCheck whether recheck is needed
      * */
     fun checkInTargetApp(
         targetApps: List<AMTargetApp>,
@@ -48,7 +48,7 @@ internal class AMCheckTargetApp(
             "======package:${eventPackage} -->class:${event.className} "
         )
         AMLog.onEDebugLog("====== Node:" + rootNode?.packageName)
-        //如果是当前包名,默认就在微信中
+        //If this is the current package name, treat it as already inside We Chat
         val packageNames = targetApps.joinToString(separator = ", ") { it.packageName }
         if (packageNames.contains(eventPackage)) {
             AMLog.onEDebugLog(
@@ -61,7 +61,7 @@ internal class AMCheckTargetApp(
             cancelReCheck()
             return true
         }
-        //兜底策略:通过node进行mCheckCount次检测
+        //Fallback: check mCheckCount times through nodes
         if (packageNames.contains(rootNode?.packageName?.toString() ?: "")) {
             startCheckInTargetAppByTimer()
             return true
@@ -80,7 +80,7 @@ internal class AMCheckTargetApp(
     }
 
     /**
-     * 取消重新检测
+ * Cancel recheck
      * */
     fun cancelReCheck() {
         mTmpCount = 0
@@ -90,7 +90,7 @@ internal class AMCheckTargetApp(
         mCheckTimerTask = null
     }
 
-    //倒计时
+    //Countdown
     private inner class BroadcastTimerTask : TimerTask() {
         override fun run() {
             mTmpCount++

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/context/AMContext.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/context/AMContext.kt
@@ -24,15 +24,15 @@ internal class AMContext(
 ) : AMCheckTargetAppListener {
 
     companion object {
-        //是否在目标App内
+        //Whether in the target app
         @Volatile
         var isInTargetApp: Boolean = false
     }
 
-    //目标app检测
+    //Targetapp Check
     private val checkTargetApp = AMCheckTargetApp(this, this)
 
-    //悬浮/组件管理
+    //Floating/component management
     val windowManager = AMWindowManager()
     var componentManager: AMCompManager? = null
         set(value) {
@@ -40,10 +40,10 @@ internal class AMContext(
             field?.let { addForeOrBackObserver(it) }
         }
 
-    //任务管理
+    //Task management
     var taskManager: AMTaskManager = AMTaskManager(this)
 
-    //根结点缓存
+    //Root node cache
     @Volatile
     private var mRootNode: AccessibilityNodeInfo? = null
 
@@ -56,7 +56,7 @@ internal class AMContext(
                     SelectToSpeakService.service?.windows?.let {
                         it.forEach { windowInfo ->
                             if (windowInfo != null) {
-                                //windowInfo.root是get方法，直接判断空，下面的不一定不为空，所以用?
+                                //window Info.root is a getter; even if the direct null check passes, values below may still be null, so use ?
                                 val tempPackageName = windowInfo.root?.packageName
                                 if (tempPackageName != null && packageNames.contains(tempPackageName.toString())) {
                                     return windowInfo.root
@@ -73,40 +73,40 @@ internal class AMContext(
         }
     }
 
-    //流程状态回调
+    //Process status callback
     var processListener: IAMProcessListener? = null
 
-    //前后台监听
+    //Foreground/background listener
     private val foreOrBackObservers = mutableListOf<IAMCompForeBackObserver>()
 
     /**
-     * 添加前后台监听
+ * Add Foreground/background listener
      * */
     fun addForeOrBackObserver(observer: IAMCompForeBackObserver) {
         foreOrBackObservers.add(observer)
     }
 
     /**
-     * 检测是否在目标APP，并分发给任务
+ * Check whether in the target app and dispatch to the task
      * */
     fun checkTargetAndDispatchTaskManager(event: AccessibilityEvent) {
         val rootNode = rootNode()
-        //先检测：
+        //Check first:
         if (event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED) {
-            //只有（窗口-状态改变）才去检测
+            //Check only for window state changes
             val isInTargetApp =
                 checkTargetApp.checkInTargetApp(targetApps, rootNode, event)
-            //监听结果
+            //Observe result
             observeInTargetApp(isInTargetApp, rootNode)
         }
-        //任务分发：
+        //Task dispatch:
         if (taskManager.isStartTool) {
             taskManager.observeAccessibilityEventInTask(isInTargetApp, event)
         }
     }
 
     /**
-     * 监听是否在目标内
+ * Observe whether inside target
      * */
     private fun observeInTargetApp(
         inTargetApp: Boolean,
@@ -181,7 +181,7 @@ internal class AMContext(
     }
 
     /**
-     * 当前组件是否事件穿透（目前支持挂起弹窗）
+ * Whether the current component allows event pass-through; currently supports suspended dialogs
      * */
     fun changeCompEventStrike(isStrike: Boolean) {
         val curComps = componentManager?.allComponent()
@@ -199,7 +199,7 @@ internal class AMContext(
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                      释放
+    // Release
     //
     /////////////////////////////////////////////////////////////////////////////////
 
@@ -217,42 +217,42 @@ internal class AMContext(
 }
 
 /**
- * 子管理的生命周期
+ * Child manager lifecycle
  * */
 interface IAMSubManagerLifeCycle {
 
-    //执行
+    //execute
     fun onExecute(taskCls: KClass<*>, dataContainer: AMDataContainer?) {
 
     }
 
-    //释放
+    //Release
     fun onDestroy()
 }
 
 /**
- * 整体流程回调状态
+ * Overall process callback status
  * */
 interface IAMProcessListener {
 
-    //任务开始
+    //Task started
     fun onProcessTaskStart() {}
 
     /**
-     * 任务暂停
-     * @param isActive 是否主动暂停
+ * Task paused
+ * @param is Active whether the pause is active
      */
     fun onProcessTaskPause(isActive: Boolean = true) {}
 
-    //任务恢复
+    //Task resumed
     fun onProcessTaskResume() {}
 
     /**
-     * 任务完成
-     * @param isSuccess 是否成功
-     * @param elapsedTime 耗时
-     * @param exception 异常
-     * @param sucData 数据
+ * Task complete
+ * @param is Success whether execution succeeded
+ * @param elapsed Time elapsed time
+ * @param exception exception
+ * @param suc Data data
      */
     fun onProcessTaskFinish(
         isSuccess: Boolean,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/data/AMDataContainer.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/data/AMDataContainer.kt
@@ -4,7 +4,7 @@ import com.coremate.opengui.automation.biz.type.AMTaskBizType
 
 data class AMDataContainer(val bizType: AMTaskBizType? = null, var bean: Any? = null) {
 
-    //额外信息
+    //Extra info
     var extra: Any? = null
 
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/exception/AMTaskException.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/exception/AMTaskException.kt
@@ -1,24 +1,24 @@
 package com.coremate.opengui.automation.base.exception
 
-///失败原因
+///Failure reason
 enum class AMTaskErrorReason(val text: String) {
-    //暂停
+    //Pause
     PAUSE("PAUSE"),
 
-    //正常 停止
+    //Normal stop
     STOP("STOP"),
 
-    //崩溃
+    //Crash
     CRASH("CRASH"),
 
-    //业务异常
+    //Business exception
     BUSINESS("BUSINESS"),
 
-    //服务中断
+    //Service interruption
     INTERRUPT("INTERRUPT")
 }
 
-///异常
+///Exception
 class AMTaskException private constructor(
     val reason: AMTaskErrorReason,
     override val cause: Throwable? = null,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/permission/CaptureManager.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/permission/CaptureManager.kt
@@ -14,7 +14,7 @@ import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
 import com.coremate.opengui.automation.base.utils.AMScreenUtils
 
-//截屏管理
+//Screenshot manager
 class CaptureManager {
 
     companion object {
@@ -35,7 +35,7 @@ class CaptureManager {
     private var mMediaProjectionManager: MediaProjectionManager? = null
 
     /**
-     * 开启截屏权限
+ * Request screenshot permission
      */
     fun openCapture(context: Activity?) {
         if (isOpenPermission) return
@@ -47,7 +47,7 @@ class CaptureManager {
     }
 
     /**
-     * 获取媒体
+ * Get media
      * */
     @SuppressLint("WrongConstant")
     fun setMediaProjection(resultCode: Int, data: Intent?) {
@@ -58,7 +58,7 @@ class CaptureManager {
     }
 
     /**
-     * 截图
+ * Screenshot
      * */
     fun startTask(listener: CaptureManagerListener?) {
         synchronized(this) {
@@ -96,7 +96,7 @@ class CaptureManager {
                                 Bitmap.Config.ARGB_8888
                             )
                             createBitMap.copyPixelsFromBuffer(buffer)
-                            // 创建 Bitmap 对象
+                            // Create Bitmap object
                             val bitmap = createBitMap.copy(Bitmap.Config.ARGB_8888, true)
                             image.close()
                             listener?.onScreenBitmap(bitmap)

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseStep.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseStep.kt
@@ -5,23 +5,23 @@ import com.coremate.opengui.automation.base.data.AMDataContainer
 import com.coremate.opengui.automation.base.utils.AMLog
 
 /**
- * 步骤
+ * Step
  * */
 internal abstract class AMBaseStep<T : AMBaseStepHelper>(
     val index: Int,
     protected val helper: T,
 ) {
 
-    //是否需要分发子步骤的功能
+    //Whether substep dispatch is needed
     open val isDispatcher = false
 
-    //子步骤索引
+    //Substep index
     protected var subStepIndex = 4
 
     /**
-     * 执行主步骤
-     *  @param data 数据
-     *  @param isResume 是否恢复
+ * Execute main step
+ * @param data data
+ * @param is Resume whether this is a resume
      * */
     @CallSuper
     open fun onExecute(
@@ -44,9 +44,9 @@ internal abstract class AMBaseStep<T : AMBaseStepHelper>(
     }
 
     /**
-     * 执行子步骤
-     * @param subStep 子步骤
-     * @param data 数据
+ * Execute substep
+ * @param subStep substep
+ * @param data data
      * @param
      * @return Pair<isIsIntercept,isCanNext>
      * */
@@ -54,17 +54,17 @@ internal abstract class AMBaseStep<T : AMBaseStepHelper>(
         subStep: AMBaseStep<*>?,
         data: AMDataContainer? = null
     ): Pair<Boolean, Boolean> {
-        //是否可以进行下一步
+        //Whether the next step can proceed
         var isCanNext = true
-        //是否被拦截
+        //Whether intercepted
         var isIsIntercept = false
         subStep?.onExecute(data)?.let {
-            //记录子步骤索引
+            //RecordSubstep index
             subStepIndex = it.index
-            //赋值
+            //Assign value
             isCanNext = it.isCanNext
             isIsIntercept = it.isIntercept
-            //判断出错
+            //Check for errors
             if (!isCanNext) {
                 AMLog.onEDebugLog("第${it.index}步出错")
             }
@@ -73,9 +73,9 @@ internal abstract class AMBaseStep<T : AMBaseStepHelper>(
     }
 
     /**
-     * 执行子步骤扩展
-     * @param subStep 子步骤
-     * @param data 数据
+ * Execute substep extension
+ * @param subStep substep
+ * @param data data
      * @param
      * @return Pair<isIsIntercept,isCanNext>
      * */
@@ -83,19 +83,19 @@ internal abstract class AMBaseStep<T : AMBaseStepHelper>(
         subStep: AMBaseStep<*>?,
         data: AMDataContainer? = null
     ): Triple<Boolean, Boolean, Any?> {
-        //是否可以进行下一步
+        //Whether the next step can proceed
         var isCanNext = true
-        //是否被拦截
+        //Whether intercepted
         var isIsIntercept = false
         var extra: Any? = null
         subStep?.onExecute(data)?.let {
-            //记录子步骤索引
+            //RecordSubstep index
             subStepIndex = it.index
-            //赋值
+            //Assign value
             isCanNext = it.isCanNext
             isIsIntercept = it.isIntercept
             extra = it.extra
-            //判断出错
+            //Check for errors
             if (!isCanNext) {
                 AMLog.onEDebugLog("第${it.index}步出错")
             }
@@ -103,15 +103,15 @@ internal abstract class AMBaseStep<T : AMBaseStepHelper>(
         return Triple(isIsIntercept, isCanNext, extra)
     }
 
-    //释放
+    //Release
     abstract fun onDestroy()
 }
 
 /**
- * 条件判断
- * @param index 当步骤
- * @param isIntercept 是否拦截
- * @param isCanNext 是否可以进行下一步
+ * Condition check
+ * @param index current step
+ * @param is Intercept whether intercepted
+ * @param is Can Next Whether the next step can proceed
  * */
 class AMStepCondition private constructor(
     val index: Int,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseStepHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseStepHelper.kt
@@ -11,23 +11,23 @@ import java.util.concurrent.ThreadPoolExecutor
 import kotlin.reflect.KClass
 
 /**
- * 步骤辅助类
+ * Step Helper Class
  * */
 internal abstract class AMBaseStepHelper {
 
-    //上下文
+    //Context
     lateinit var amContext: AMContext
 
-    //当前任务状态
+    //Current task Status
     private var curTaskState: AMTaskState? = null
 
-    //主线程handler
+    //Main-thread handler
     val mainHandler by lazy { Handler(Looper.getMainLooper()) }
 
-    //任务开始时间
+    //Task start time
     var startTime: Long = 0
 
-    //当前执行的步骤索引（默认从1开始）
+    //Current step index, starting at 1 by default
     @Volatile
     var setStepIndex = 1
         set(value) {
@@ -41,11 +41,11 @@ internal abstract class AMBaseStepHelper {
 
     lateinit var executorService: ThreadPoolExecutor
 
-    //所有步骤
+    //All steps
     private var steps = mutableListOf<AMBaseStep<*>>()
 
     /**
-     * 注册步骤
+ * Register Step
      * */
     fun registerSteps(vararg steps: KClass<*>) {
         AMLog.onEDebugLog("成功注册${steps.size}个步骤")
@@ -57,7 +57,7 @@ internal abstract class AMBaseStepHelper {
     }
 
     /**
-     * 开始执行步骤
+ * Start execution Step
      * */
     fun onStartStep() {
         executorService.execute {
@@ -67,7 +67,7 @@ internal abstract class AMBaseStepHelper {
     }
 
     /**
-     * 任务状态改变
+ * Task status changed
      * */
     fun onNotifyTaskStateChanged(isStopThrows: Boolean) {
 
@@ -94,7 +94,7 @@ internal abstract class AMBaseStepHelper {
                     executorService.execute {
                         AMLog.onEDebugLog("任务暂停")
                         amContext.taskManager.setTaskResume = false
-                        //抛出异常
+                        //Throw exception
                         throw AMTaskException.pause()
                     }
                 } else {
@@ -106,7 +106,7 @@ internal abstract class AMBaseStepHelper {
                 executorService.execute {
                     AMLog.onEDebugLog("任务结束")
                     amContext.taskManager.setTaskResume = false
-                    //抛出异常
+                    //Throw exception
                     if (isStopThrows) {
                         throw AMTaskException.stop()
                     }
@@ -124,117 +124,117 @@ internal abstract class AMBaseStepHelper {
     protected abstract fun onObserveTaskResume()
 
     /**
-     * 获取第一步
+ * Get Step 1
      * */
     fun firstStep() = this[0]
 
     /**
-     * 获取第二步
+ * Get Step 2
      * */
     fun secondStep() = this[1]
 
     /**
-     * 获取第三步
+ * Get Step 3
      * */
     fun thirdStep() = this[2]
 
     /**
-     * 获取第四步
+ * Get Step 4
      * */
     fun forthStep() = this[3]
 
     /**
-     * 获取第五步
+ * Get Step 5
      * */
     fun fiveStep() = this[4]
 
     /**
-     * 获取第六步
+ * Get Step 6
      * */
     fun sixStep() = this[5]
 
     /**
-     * 获取第七步
+ * Get Step 7
      * */
     fun sevenStep() = this[6]
 
     /**
-     * 获取第八步
+ * Get Step 8
      * */
     fun eightStep() = this[7]
 
     /**
-     * 获取第九步
+ * Get Step 9
      * */
     fun nineStep() = this[8]
 
     /**
-     * 获取第十步
+ * Get Step 10
      * */
     fun tenStep() = this[9]
 
     /**
-     * 获取第十一步
+ * Get Step 11
      * */
     fun elevenStep() = this[10]
 
     /**
-     * 获取第十二步
+ * Get step 12
      * */
     fun twelveStep() = this[11]
 
     /**
-     * 获取第13步
+ * Get Step 13
      * */
     fun thirteenStep() = this[12]
 
     /**
-     * 获取第14步
+ * Get Step 14
      * */
     fun fourteenStep() = this[13]
 
     /**
-     * 获取第15步
+ * Get Step 15
      * */
     fun fifteenStep() = this[14]
 
     /**
-     * 获取第16步
+ * Get Step 16
      * */
     fun sixteenStep() = this[15]
 
     /**
-     * 获取第17步
+ * Get Step 17
      * */
     fun seventeenStep() = this[16]
 
     /**
-     * 获取第18步
+ * Get Step 18
      * */
     fun eightTeenStep() = this[17]
 
     /**
-     * 获取第n步
+ * Get step n
      * */
     protected operator fun get(index: Int): AMBaseStep<*>? =
         if (index < steps.size) steps[index] else null
 
     /**
-     * 任务是否暂停或者停止
+ * Whether the task is paused or stopped
      * */
     fun isTaskPauseOrStop(): Boolean {
         return amContext.taskManager.taskState == AMTaskState.PAUSE || amContext.taskManager.taskState == AMTaskState.STOP
     }
 
     /**
-     * 任务是否停止
+ * Whether the task is stopped
      * */
     fun isTaskStop(): Boolean {
         return amContext.taskManager.taskState == AMTaskState.STOP
     }
 
     /**
-     * 主线程执行
+ * Run on main thread
      * */
     inline fun postMainHandler(crossinline action: () -> Unit, delay: AMActionDelay? = null) {
         if (delay != null) {
@@ -249,7 +249,7 @@ internal abstract class AMBaseStepHelper {
     }
 
     /**
-     * 释放
+ * Release
      * */
     @CallSuper
     open fun onDestroy() {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseTask.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMBaseTask.kt
@@ -10,16 +10,16 @@ import java.util.concurrent.ThreadPoolExecutor.DiscardPolicy
 import java.util.concurrent.TimeUnit
 
 /**
- * 任务基类
+ * Base task class
  * */
 internal abstract class AMBaseTask<T : AMBaseStepHelper>(val amContext: AMContext) {
 
     protected var helper: T = AMUtils.getT(this, 0) as T
 
     init {
-        //上下文
+        //Context
         helper.amContext = amContext
-        //线程池
+        //Thread pool
         helper.executorService = ThreadPoolExecutor(
             1,
             1,
@@ -32,27 +32,27 @@ internal abstract class AMBaseTask<T : AMBaseStepHelper>(val amContext: AMContex
     }
 
     /**
-     * 任务初始化
+ * Initialize task
      * */
     abstract fun initTaskAndData(dataContainer: AMDataContainer?)
 
 
     /**
-     * 任务执行(子线程)
+ * Execute task on background thread
      * */
     open fun onExecute() {
         helper.onStartStep()
     }
 
     /**
-     * 任务状态改变
+ * Task status changed
      * */
     fun onObserveTaskStateChanged(isStopThrows: Boolean) {
         helper.onNotifyTaskStateChanged(isStopThrows)
     }
 
     /**
-     * 任务销毁
+ * Destroy task
      * */
     @CallSuper
     open fun onDestroy() {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMTaskManager.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/task/AMTaskManager.kt
@@ -11,26 +11,26 @@ import com.coremate.opengui.automation.base.utils.AMLog
 import kotlin.reflect.KClass
 
 enum class AMTaskState {
-    START, //开始
-    RESUME, //恢复
-    PAUSE, //暂停
-    STOP, //结束
+    START, // Start.
+    RESUME, // Resume.
+    PAUSE, // Pause.
+    STOP, // Stop.
 }
 
 internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLifeCycle {
 
-    //是否开始使用工具
+    //Whether tool use has started
     var isStartTool = false
 
-    //当前任务
+    //Current task
     var task: AMBaseTask<*>? = null
 
-    //任务状态改变监听
+    //Task status change listener
     var listener: AMTaskChangedListener? = null
 
     /**
-     * 设置任务状态
-     * @param isStopThrows (默认设置结束状态时，不抛出异常)
+ * Set task status
+ * @param is Stop Throws whether to throw when setting stop status; default does not throw
      */
     fun setTaskState(taskState: AMTaskState, isStopThrows: Boolean = false) {
         synchronized(this) {
@@ -42,12 +42,12 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
     @Volatile
     private var setTaskState = AMTaskState.STOP
 
-    //获取任务状态
+    //Get task status
     val taskState: AMTaskState
         get() = setTaskState
 
 
-    //设置恢复或者暂停
+    //Set resume or pause
     @Volatile
     var setTaskResume = true
         set(value) {
@@ -57,21 +57,21 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
             }
         }
 
-    //是否恢复
+    //Whether resumed
     val isTaskResume: Boolean
         get() = setTaskResume
 
-    //记录是否在wx
+    //Record whether in We Chat
     private var isRecordInWx = false
 
     /**
-     * 执行任务
+ * Execute task
      * */
     override fun onExecute(taskCls: KClass<*>, dataContainer: AMDataContainer?) {
         if (task == null) {
             task = taskCls.constructors.first().call(amContext) as AMBaseTask<*>
         }
-        //执行时，再次判断是否在目前App内
+        //Check again at execution time whether the current app is active
         val rootNodePackage = amContext.rootNode()?.packageName ?: ""
         val packageNames = amContext.targetApps.joinToString(separator = ", ") { it.packageName }
         if (packageNames.contains(rootNodePackage.toString())) {
@@ -79,9 +79,9 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
         }
         if (AMContext.isInTargetApp) {
             amContext.processListener?.onProcessTaskStart()
-            //任务初始化
+            //Initialize task
             task?.initTaskAndData(dataContainer)
-            //延时执行任务（为等带有键盘组件隐藏之后移除焦点）
+            //Delay task execution until the keyboard component hides and focus is cleared
             Handler(Looper.getMainLooper()).postDelayed({
                 task?.onExecute()
             }, AMActionDelay.SHORT.millis)
@@ -92,7 +92,7 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
     }
 
     /**
-     * 辅助监听
+ * Helper listener
      * */
     fun observeAccessibilityEventInTask(isInTargetApp: Boolean, event: AccessibilityEvent) {
         if (amContext.taskManager.taskState != AMTaskState.STOP) {
@@ -100,9 +100,9 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
                 return
             }
             if (isInTargetApp) {
-                //任务正在执行中
+                //Task is running
             } else {
-                //暂停任务
+                //Pause task
                 AMLog.onEDebugLog("不在目标App，任务暂停2")
                 amContext.processListener?.onProcessTaskPause(false)
             }
@@ -111,7 +111,7 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
     }
 
     /**
-     * 任务状态改变
+ * Task status changed
      * */
     private fun onObserveTaskStateChanged(isStopThrows: Boolean) {
         task?.onObserveTaskStateChanged(isStopThrows)
@@ -126,9 +126,9 @@ internal class AMTaskManager(private val amContext: AMContext) : IAMSubManagerLi
 }
 
 /**
- * 任务状态真实改变回调
+ * Real task status change callback
  * */
 interface AMTaskChangedListener {
-    //状态改变
+    //Status changed
     fun onChanged()
 }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMEventUtils.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMEventUtils.kt
@@ -24,7 +24,7 @@ enum class AMActionDelay(val millis: Long) {
 }
 
 /**
- * 事件工具
+ * Event utilities
  * */
 internal object AMEventUtils {
 
@@ -33,12 +33,12 @@ internal object AMEventUtils {
     }
 
     /**
-     * 执行事件
-     * @param times 执行次数（失败之后继续执行直到times结束）
-     * @param delay 事件延时
-     * @param something 回调
-     * @param isInterruptIgnore 过滤中断
-     * @return 返回结果枚举
+ * Execute event
+ * @param times execution count; continue after failures until times is exhausted
+ * @param delay event delay
+ * @param something callback
+ * @param is Interrupt Ignore ignore interruption
+ * @return result enum
      * */
     fun reProcessUntilOk(
         helper: AMBaseStepHelper,
@@ -75,10 +75,10 @@ internal object AMEventUtils {
     }
 
     /**
-     * 执行事件
-     * @param times 执行次数（失败之后继续执行直到times结束）
-     * @param delay 事件延时
-     * @param something 回调
+ * Execute event
+ * @param times execution count; continue after failures until times is exhausted
+ * @param delay event delay
+ * @param something callback
      * */
     internal fun <T> doSomethingUntilSuccess(
         times: Int,
@@ -86,7 +86,7 @@ internal object AMEventUtils {
         something: Something<T>
     ): T? {
         var curIndex = 0
-        val maxTimes = 1.coerceAtLeast(times) //最小1次
+        val maxTimes = 1.coerceAtLeast(times) // At least one attempt.
         while (true) {
             var result: T? = null
             if (curIndex < maxTimes) {
@@ -95,7 +95,7 @@ internal object AMEventUtils {
                 if (isSuc) {
                     return result
                 } else {
-                    //增加中断
+                    //Add interruption
                     try {
                         if (something.workInterruput()) {
                             return result
@@ -113,7 +113,7 @@ internal object AMEventUtils {
     }
 
     /**
-     * 遍历父节点点击（默认尝试10次）
+ * Traverse parent nodes and tap, up to 10 attempts by default
      * */
     fun clickFirstClickableParent(
         nodeInfo: AccessibilityNodeInfo?,
@@ -146,7 +146,7 @@ internal object AMEventUtils {
     }
 
     /**
-     * 遍历父节点点击（默认尝试10次）
+ * Traverse parent nodes and tap, up to 10 attempts by default
      * */
     fun clickFirstClickableParentWithSimulate(
         nodeInfo: AccessibilityNodeInfo?,
@@ -183,14 +183,14 @@ internal object AMEventUtils {
     }
 
     /**
-     * 模拟点击
+ * Simulate tap
      * */
     fun doClickDown(
         nodeInfo: AccessibilityNodeInfo?,
         helper: AMBaseStepHelper? = null,
     ): Boolean {
         AMLog.onEDebugLog("使用模拟点击")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -219,7 +219,7 @@ internal object AMEventUtils {
             },
             null
         ) ?: false
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -232,7 +232,7 @@ internal object AMEventUtils {
         y: Float = 0f
     ): Boolean {
         AMLog.onEDebugLog("使用模拟点击")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -258,7 +258,7 @@ internal object AMEventUtils {
             },
             null
         ) ?: false
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -271,7 +271,7 @@ internal object AMEventUtils {
         x: Float = 0f,
     ): Boolean {
         AMLog.onEDebugLog("使用模拟点击")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -300,7 +300,7 @@ internal object AMEventUtils {
             },
             null
         ) ?: false
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -312,7 +312,7 @@ internal object AMEventUtils {
         y: Float = 0f,
     ): Boolean {
         AMLog.onEDebugLog("使用模拟点击")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -339,7 +339,7 @@ internal object AMEventUtils {
             },
             null
         ) ?: false
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -347,14 +347,14 @@ internal object AMEventUtils {
     }
 
     /**
-     * 模拟双击
+ * Simulate double tap
      */
     fun doDoubleClick(
         nodeInfo: AccessibilityNodeInfo?,
         helper: AMBaseStepHelper? = null,
     ): Boolean {
         AMLog.onEDebugLog("使用模拟双击")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -366,7 +366,7 @@ internal object AMEventUtils {
         path.moveTo(rect.centerX().toFloat(), rect.centerY().toFloat())
         val gesture = GestureDescription.Builder()
             .addStroke(GestureDescription.StrokeDescription(path, 0, 1))
-            .addStroke(GestureDescription.StrokeDescription(path, 100, 1)) // 第二次点击，延迟100ms
+            .addStroke(GestureDescription.StrokeDescription(path, 100, 1)) // Second tap, delayed by 100 ms.
             .build()
         val clickAble = SelectToSpeakService.service?.dispatchGesture(
             gesture,
@@ -381,7 +381,7 @@ internal object AMEventUtils {
             },
             null
         ) ?: false
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -390,7 +390,7 @@ internal object AMEventUtils {
 
 
     /**
-     * 模拟长按
+ * Simulate Long press
      * */
     fun doLongClickDown(
         nodeInfo: AccessibilityNodeInfo?,
@@ -398,7 +398,7 @@ internal object AMEventUtils {
     ): Boolean {
         if (nodeInfo == null) return false
         AMLog.onEDebugLog("使用模拟长按")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -427,7 +427,7 @@ internal object AMEventUtils {
             null
         ) ?: false
 
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
         }
@@ -435,14 +435,14 @@ internal object AMEventUtils {
     }
 
     /**
-     * 模拟滑动
+ * Simulate Swipe
      * */
     fun doSwipeUp(
         nodeInfo: AccessibilityNodeInfo?,
         helper: AMBaseStepHelper? = null,
     ): Boolean {
         AMLog.onEDebugLog("使用模拟上滑动")
-        //将悬浮窗事件穿透
+        //Enable floating-window event pass-through
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -477,7 +477,7 @@ internal object AMEventUtils {
             null
         ) ?: false
 
-        //将悬浮窗事件恢复
+        //Restore floating-window event handling
         sleep(AMActionDelay.MIDDLE)
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
@@ -492,7 +492,7 @@ internal object AMEventUtils {
     ): Boolean {
         AMLog.onEDebugLog("使用模拟上滑动 $px 像素")
 
-        // 开启事件穿透（避免悬浮窗拦截）
+        // Enable event pass-through to avoid floating-window interception
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(true)
         }
@@ -503,18 +503,18 @@ internal object AMEventUtils {
         if (nodeInfo == null || SelectToSpeakService.service == null) return false
         nodeInfo.getBoundsInScreen(rect)
 
-        // 创建滑动路径（垂直滑动30像素）
+        // Create swipe path with 30 px vertical movement
         val path = Path()
         val startX = rect.left + 55
-        val startY = rect.centerY() + px / 2   // 中心下方 px/2 像素
+        val startY = rect.centerY() + px / 2   // px / 2 below center.
         val endX = rect.left + 55
-        val endY = rect.centerY() - px / 2     // 中心上方 px/2 像素
+        val endY = rect.centerY() - px / 2     // px / 2 above center.
 
         path.moveTo(startX.toFloat(), startY.toFloat())
         path.lineTo(endX.toFloat(), endY.toFloat())
 
         val gesture = GestureDescription.Builder()
-            .addStroke(GestureDescription.StrokeDescription(path, 0, 100)) // 200ms 滑动
+            .addStroke(GestureDescription.StrokeDescription(path, 0, 100)) // 200 ms swipe.
             .build()
 
         sleep(AMActionDelay.MINI)
@@ -535,7 +535,7 @@ internal object AMEventUtils {
             null
         ) ?: false
 
-        // 恢复事件阻断状态
+        // Restore event blocking state
         sleep(AMActionDelay.MIDDLE)
         Handler(Looper.getMainLooper()).post {
             helper?.amContext?.changeCompEventStrike(false)
@@ -546,7 +546,7 @@ internal object AMEventUtils {
 
 
     /**
-     * 上下滑动
+ * Vertical swipe
      * */
     fun scroll2TopOrBottom(
         listView: AccessibilityNodeInfo?,
@@ -568,7 +568,7 @@ internal object AMEventUtils {
     }
 
     /**
-     * 输入框填充内容
+ * Fill input field content
      */
     fun setTextToEditText(nodeInfo: AccessibilityNodeInfo?, text: String): Boolean {
         if (nodeInfo == null) return false
@@ -582,7 +582,7 @@ internal object AMEventUtils {
     }
 
     /**
-     * 给输入框焦点
+ * Focus the input field
      * */
     fun setFocusToEditText(nodeInfo: AccessibilityNodeInfo?): Boolean {
         if (nodeInfo == null) return false
@@ -600,10 +600,10 @@ sealed class SomethingEvent {
             is Result -> {
                 val s = result ?: false
                 if (s) {
-                    //成功
+                    //Success
                     action(true, intercept)
                 } else {
-                    //失败
+                    //Failure
                     action(false, intercept)
                 }
                 return
@@ -613,17 +613,17 @@ sealed class SomethingEvent {
 }
 
 /**
- * 执行事件回调
- * @param T 返回类型
+ * Execute event callback
+ * @param T return type
  * */
 interface Something<T> {
-    //判断成功返回T
+    //Check Success BackT
     fun judgmentSuccess(result: T): Boolean
 
-    //工作(多次)
+    //Work multiple times
     fun work(timeIndex: Int): T
 
-    //中断
+    //Interrupt
     fun workInterruput(): Boolean {
         return false
     }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMLog.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMLog.kt
@@ -7,7 +7,7 @@ class AMLog {
 
     companion object {
         /**
-         * 仅做调试打印
+ * Debug logging only
          */
         fun onEDebugLog(log: String) {
             if (BuildConfig.DEBUG) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMNodeUtils.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMNodeUtils.kt
@@ -3,12 +3,12 @@ package com.coremate.opengui.automation.base.utils
 import android.view.accessibility.AccessibilityNodeInfo
 
 /**
- * 节点工具
+ * Node utilities
  * */
 object AMNodeUtils {
 
     /**
-     * 通过Id获取第一个NodeInfo
+ * Get the first Node Info by ID
      */
     fun getFirstNodeById(
         nodeInfo: AccessibilityNodeInfo?,
@@ -24,7 +24,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Id获取第一个NodeInfo (条件)
+ * Get the first Node Info by ID with predicate
      */
     fun getFirstNodeByIdWithCallback(
         parentOrRoot: AccessibilityNodeInfo?,
@@ -58,7 +58,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 根据id获取节点
+ * Get node by ID
      * */
     private fun findNodesById(
         parentOrRoot: AccessibilityNodeInfo?,
@@ -78,7 +78,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Id获取全部NodeInfo (精准)
+ * Get all Node Info by ID exactly
      */
     fun getAllNodeById(
         nodeInfo: AccessibilityNodeInfo?,
@@ -93,7 +93,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Text获取第一个NodeInfo
+ * Get the first Node Info by text
      */
     fun getFirstNodeByText(
         nodeInfo: AccessibilityNodeInfo?,
@@ -121,7 +121,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Desc获取第一个NodeInfo
+ * Get the first Node Info by desc
      */
     fun getFirstNodeByDesc(
         nodeInfo: AccessibilityNodeInfo?,
@@ -150,7 +150,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Desc获取第一个NodeInfo
+ * Get the first Node Info by desc
      */
     fun getFirstNodeByDescCallBack(
         nodeInfo: AccessibilityNodeInfo?,
@@ -175,7 +175,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过ID和Text模糊匹配 获取第一个NodeInfo
+ * Get the first Node Info by fuzzy ID and text match
      */
     fun getFirstNodeByIdWithContainText(
         nodeInfo: AccessibilityNodeInfo?,
@@ -199,7 +199,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过className获取节点
+ * Get node by class Name
      */
     fun getNodeByClassName(
         nodeInfo: AccessibilityNodeInfo?,
@@ -224,7 +224,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过ClassName获取同层布局第一个
+ * Get the first sibling layout by Class Name
      */
     fun getBrotherNodeByClassName(
         nodeInfo: AccessibilityNodeInfo?,
@@ -255,7 +255,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过ClassName获取全部NodeInfo (精准)
+ * Get all Node Info by Class Name exactly
      */
     fun getAllNodeByClassName(
         nodeInfo: AccessibilityNodeInfo?,
@@ -279,7 +279,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Desc及ClassName获取第一个NodeInfo
+ * Get the first Node Info by desc and class Name
      */
     fun getFirstNodeByDescWithClassName(
         nodeInfo: AccessibilityNodeInfo?,
@@ -301,7 +301,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 通过Desc及ClassName获取第一个NodeInfo
+ * Get the first Node Info by desc and class Name
      */
     fun getAllNodeContainDesc(
         nodeInfo: AccessibilityNodeInfo?,
@@ -326,7 +326,7 @@ object AMNodeUtils {
 
 
     /**
-     * 获取节点
+ * Get node
      * */
     private fun findNode(
         accessibilityNodeInfo: AccessibilityNodeInfo?,
@@ -396,7 +396,7 @@ object AMNodeUtils {
     }
 
     /**
-     * 获取子节点
+ * Get child nodes
      * */
     fun findChildNodes(
         rootNode: AccessibilityNodeInfo?,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMPermissionUtils.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMPermissionUtils.kt
@@ -16,12 +16,12 @@ class AMPermissionUtils {
 
         /////////////////////////////////////////////////////////////////////////////////
         //
-        //                      权限
+        // Permission
         //
         /////////////////////////////////////////////////////////////////////////////////
 
         /**
-         * 检查是否开启辅助权限
+ * Check Whether accessibility permission is enabled
          */
         fun hasAccessibilityPermission(ct: Context, serviceClass: Class<*>): Boolean {
             var ok = 0
@@ -56,14 +56,14 @@ class AMPermissionUtils {
         }
 
         /**
-         * 跳转到设置页的辅助功能
+ * Navigate to accessibility settings
          */
         fun openAccessibilitySetting(ct: Context) {
             ct.startActivity(Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS))
         }
 
         /**
-         * 检查悬浮窗权限
+ * Check Floating window Permission
          */
         fun hasAlertWindowPermission(context: Context): Boolean {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
@@ -95,13 +95,13 @@ class AMPermissionUtils {
         }
 
         /**
-         * 请求悬浮窗权限
+ * Request floating-window permission
          * @param activity
          * @param REQUEST_DIALOG_PERMISSION
          */
         fun openAlertWindowSetting(activity: Activity, REQUEST_DIALOG_PERMISSION: Int) {
             val sdkInt = Build.VERSION.SDK_INT
-            if (sdkInt >= Build.VERSION_CODES.O) { //8.0以上
+            if (sdkInt >= Build.VERSION_CODES.O) { // Android 8.0 and above.
                 val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
                 intent.data = Uri.parse("package:" + activity.packageName)
                 activity.startActivityForResult(intent, REQUEST_DIALOG_PERMISSION)
@@ -109,8 +109,8 @@ class AMPermissionUtils {
                 val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)
                 intent.data = Uri.parse("package:" + activity.packageName)
                 activity.startActivityForResult(intent, REQUEST_DIALOG_PERMISSION)
-            } else { //4.4-6.0一下
-                //无需处理了.....
+            } else { // Android 4.4 to below 6.0.
+                //No handling needed.....
             }
         }
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMScreenUtils.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMScreenUtils.kt
@@ -10,34 +10,34 @@ class AMScreenUtils {
 
     companion object {
         /**
-         * 获取屏幕的宽度（单位：px）
+ * Get screen width in px
          *
-         * @return 屏幕宽px
+ * @return screen width in px
          */
         @JvmStatic
         fun screenWidth() = AMServiceManager.applicationContext.let {
             val windowManager = it.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-            val dm = DisplayMetrics() // 创建了一张白纸
-            windowManager.defaultDisplay.getMetrics(dm) // 给白纸设置宽高
+            val dm = DisplayMetrics() // Create an empty metrics object.
+            windowManager.defaultDisplay.getMetrics(dm) // Populate width and height.
             dm.widthPixels
         } ?: 0
 
         /**
-         * 获取屏幕的高度（单位：px）
+ * Get screen height in px
          *
-         * @return 屏幕高px
+ * @return screen height in px
          */
         @JvmStatic
         fun screenHeight(): Int = AMServiceManager.applicationContext.let {
             val windowManager =
                 it.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-            val dm = DisplayMetrics() // 创建了一张白纸
-            windowManager.defaultDisplay.getMetrics(dm) // 给白纸设置宽高
+            val dm = DisplayMetrics() // Create an empty metrics object.
+            windowManager.defaultDisplay.getMetrics(dm) // Populate width and height.
             dm.heightPixels
         } ?: 0
 
         /**
-         * 获取状态栏高度
+ * Get status bar height
          * */
         @JvmStatic
         fun getStatusBarHeight(): Int = Resources.getSystem().getDimensionPixelSize(

--- a/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMUtils.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/base/utils/AMUtils.kt
@@ -9,7 +9,7 @@ import java.lang.reflect.ParameterizedType
 object AMUtils {
 
     /**
-     * 跳转到app内对应的页面
+ * Navigate to the corresponding page in the app
      * */
     fun jumpToPageInApp(
         accessibilityService: SelectToSpeakService?,
@@ -30,7 +30,7 @@ object AMUtils {
     }
 
     /**
-     * 获取类中的泛型，并实例化
+ * Get the generic type from the class and instantiate it
      * */
     @JvmStatic
     fun getT(o: Any, i: Int): Any? {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/IAMPageEvent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/IAMPageEvent.kt
@@ -21,7 +21,7 @@ internal open class IAMPageEvent {
 
 
     /**
-     * 判断是否要打开app
+ * Check whether the app should be opened
      */
     fun isOpenAppAndOpen(helper: AMBaseStepHelper): Boolean {
         AMEventUtils.sleep(AMActionDelay.MINI)
@@ -36,7 +36,7 @@ internal open class IAMPageEvent {
 
                 override fun work(timeIndex: Int): Boolean {
                     val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
-                    //今后不提示
+                    //Do not prompt again
                     val checkBox =
                         AMNodeUtils.getFirstNodeById(
                             rootNode,
@@ -71,12 +71,12 @@ internal open class IAMPageEvent {
 
 
     /**
-     * 选择相册
-     * @param timeKey 时间的key
-     * @param index 索引
-     * @param extra 额外判断(默认为true)
-     * @param moreJudgment 是否存在多余判断
-     * @return Pair 是否成功 / 是否暂停
+ * Select album
+ * @param time Key time key
+ * @param index index
+ * @param extra additional predicate, true by default
+ * @param more Judgment whether extra checks exist
+ * @return Pair of success flag and pause flag
      * */
     fun selectPictureOrVideoByTimeAndIndex(
         helper: AMBaseStepHelper,
@@ -87,7 +87,7 @@ internal open class IAMPageEvent {
     ): Pair<Boolean, Boolean> {
         AMEventUtils.sleep(AMActionDelay.MINI)
         if (moreJudgment) {
-            //判断是否在选择图片视频页面
+            //Check whether on the image/video picker page
             AMEventUtils.reProcessUntilOk(
                 helper,
                 20,
@@ -119,7 +119,7 @@ internal open class IAMPageEvent {
             }
         }
         AMLog.onEDebugLog("开始处理第${index}张图片 - 获取recyclerView")
-        //获取recyclerView
+        //Get Recycler View
         var recyclerViewNode: AccessibilityNodeInfo? = null
         var alreadyWait = false
         AMEventUtils.reProcessUntilOk(
@@ -157,7 +157,7 @@ internal open class IAMPageEvent {
             }
         }
         AMLog.onEDebugLog("开始处理第${index}张图片 - 滑动")
-        //滑动
+        //Swipe
         AMEventUtils.scroll2TopOrBottom(recyclerViewNode, true)
         AMEventUtils.sleep(AMActionDelay.SHORT)
         var i = 0
@@ -191,7 +191,7 @@ internal open class IAMPageEvent {
             if (helper.isTaskPauseOrStop()) {
                 return Pair(false, true)
             }
-            //再次获取recyclerView
+            //Get RecyclerView again
             if (moreJudgment) {
                 AMCore.instance.amContext?.rootNode() ?: return Pair(false, false)
                 AMEventUtils.reProcessUntilOk(
@@ -219,23 +219,23 @@ internal open class IAMPageEvent {
             }
 
             AMLog.onEDebugLog("开始处理第${index}张图片 - 遍历其中的item")
-            //遍历其中的item
+            //Iterate its items
             for (itemNode in AMNodeUtils.getAllNodeByClassName(
                 recyclerViewNode,
                 RelativeLayout::class.java.name
             )) {
-                //过滤情况
+                //Filter cases
                 if (index > i) {
                     i++
                     continue
                 }
                 var tempImageInfo: AccessibilityNodeInfo? = null
-                //图片列表
+                //Image list
                 val imageList =
                     AMNodeUtils.getAllNodeByClassName(itemNode, ImageView::class.java.name)
                 if (imageList.isEmpty()) continue
 
-                //获取有desc的图片
+                //Get image with desc
                 val iterator = imageList.iterator()
                 while (true) {
                     if (iterator.hasNext()) {
@@ -246,7 +246,7 @@ internal open class IAMPageEvent {
                 }
                 if (tempImageInfo == null) continue
 
-                //获取图片的desc
+                //Get image desc
                 val str = (tempImageInfo.contentDescription ?: "").toString()
                 if (!str.contains(timeKey) || (extra && !str.contains("图片")) || (!extra && !str.contains(
                         "视频"
@@ -254,11 +254,11 @@ internal open class IAMPageEvent {
                 ) {
                     continue
                 }
-                //获取checkBox节点
+                //Get checkbox node
                 val checkNode =
                     AMNodeUtils.getNodeByClassName(itemNode, CheckBox::class.java.name) ?: continue
 
-                //点击checkBox
+                //Tap checkbox
                 if (!checkNode.isChecked) {
                     AMEventUtils.clickFirstClickableParentWithSimulate(checkNode, helper)
                     AMLog.onEDebugLog("开始处理第${index}张图片 - 点击checkBox")
@@ -271,12 +271,12 @@ internal open class IAMPageEvent {
     }
 
     /**
-     * 选择视频
-     * @param timeKey 时间的key
-     * @param index 索引
-     * @param extra 额外判断(默认为true)
-     * @param moreJudgment 是否存在多余判断
-     * @return Pair 是否成功 / 是否暂停
+ * Select video
+ * @param time Key time key
+ * @param index index
+ * @param extra additional predicate, true by default
+ * @param more Judgment whether extra checks exist
+ * @return Pair of success flag and pause flag
      * */
     open fun selectVideoByTimeAndIndex(
         helper: AMBaseStepHelper,
@@ -287,7 +287,7 @@ internal open class IAMPageEvent {
 
         if (moreJudgment) {
             AMCore.instance.amContext?.rootNode() ?: return Pair(false, false)
-            //判断是否在选择图片视频页面
+            //Check whether on the image/video picker page
             AMEventUtils.reProcessUntilOk(
                 helper,
                 20,
@@ -342,7 +342,7 @@ internal open class IAMPageEvent {
             AMLog.onEDebugLog("没有recyclerView")
             return Pair(false, false)
         }
-        //滑动
+        //Swipe
         AMEventUtils.scroll2TopOrBottom(recyclerViewNode, true)
         AMEventUtils.sleep(AMActionDelay.SHORT)
         var j = 0
@@ -350,7 +350,7 @@ internal open class IAMPageEvent {
             if (helper.isTaskPauseOrStop()) {
                 return Pair(false, true)
             }
-            //再次获取recyclerView
+            //Get RecyclerView again
             val rootNode = AMCore.instance.amContext?.rootNode() ?: return Pair(false, false)
             recyclerViewNode =
                 AMNodeUtils.getNodeByClassName(rootNode, RecyclerView::class.java.name)
@@ -359,18 +359,18 @@ internal open class IAMPageEvent {
                 false
             )
             AMLog.onEDebugLog("开始处理第${index}个视频 - 遍历其中的item")
-            //遍历其中的item
+            //Iterate its items
             for (itemNode in AMNodeUtils.getAllNodeByClassName(
                 recyclerViewNode,
                 RelativeLayout::class.java.name
             )) {
                 var tempImageInfo: AccessibilityNodeInfo? = null
-                //图片列表
+                //Image list
                 val imageList =
                     AMNodeUtils.getAllNodeByClassName(itemNode, ImageView::class.java.name)
                 if (imageList.isEmpty()) continue
 
-                //获取有desc的图片
+                //Get image with desc
                 val iterator = imageList.iterator()
                 while (true) {
                     if (iterator.hasNext()) {
@@ -380,7 +380,7 @@ internal open class IAMPageEvent {
                     break
                 }
                 if (tempImageInfo == null) continue
-                //获取图片的desc
+                //Get image desc
                 val str = (tempImageInfo.contentDescription ?: "").toString()
                 if (!str.contains(timeKey) || (!str.contains("视频"))) {
                     continue
@@ -393,11 +393,11 @@ internal open class IAMPageEvent {
                     j++
                     continue
                 }
-                //获取checkBox节点
+                //Get checkbox node
                 val checkNode =
                     AMNodeUtils.getNodeByClassName(itemNode, CheckBox::class.java.name) ?: continue
 
-                //点击checkBox
+                //Tap checkbox
                 if (!checkNode.isChecked) {
                     AMEventUtils.clickFirstClickableParentWithSimulate(checkNode, helper)
                     AMLog.onEDebugLog("开始处理第${index}张图片 - 点击checkBox")
@@ -473,7 +473,7 @@ internal open class IAMPageEvent {
     }
 
     /**
-     * 是否在目标app
+ * whetherin Targetapp
      * */
     fun isInTargetApp(target: AMTargetApp): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -484,7 +484,7 @@ internal open class IAMPageEvent {
     }
 
     /**
-     * 是否在目标app
+ * whetherin Targetapp
      * */
     fun isInTargetApps(targets: MutableList<AMTargetApp>): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/lv/AMLVPageEvent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/lv/AMLVPageEvent.kt
@@ -17,19 +17,19 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 internal object AMLVPageEvent : IAMPageEvent() {
 
     /**
-     * 获取返回节点
+ * Get back node
      * */
     fun getBackNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
         var nodeInfo: AccessibilityNodeInfo? = null
-        //返回节点id
+        //Back node id
         nodeInfo =
             AMNodeUtils.getFirstNodeById(rootNode, IAMWidgetLV.globalBack().resourceId)
         return nodeInfo
     }
 
     /**
-     * 是否在剪映首页
+ * Whether on Jianying home page
      */
     fun isInHomePage(helper: AMBaseStepHelper?): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -48,7 +48,7 @@ internal object AMLVPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 回到剪映首页
+ * Return to Jianying home page
      * */
     fun backHomePage(callBack: IAMTaskCallBack, helper: AMBaseStepHelper? = null) {
         AMEventUtils.doSomethingUntilSuccess(
@@ -116,7 +116,7 @@ internal object AMLVPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 返回
+ * Back
      * */
     fun simpleBack(helper: AMBaseStepHelper? = null) {
         if (!isInTargetApps(

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/red/AMRedPageEvent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/red/AMRedPageEvent.kt
@@ -17,7 +17,7 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 internal object AMRedPageEvent : IAMPageEvent() {
 
     /**
-     * 回到小红书会话
+ * Return to Xiaohongshu conversation
      * */
     fun backRedChatListPage(callBack: IAMTaskCallBack, helper: AMBaseStepHelper? = null) {
         AMEventUtils.doSomethingUntilSuccess(
@@ -75,7 +75,7 @@ internal object AMRedPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在抖音会话列表
+ * Whether on the Douyin conversation list
      */
     fun isInRedChatListPage(name: String = "消息"): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -92,7 +92,7 @@ internal object AMRedPageEvent : IAMPageEvent() {
 
 
     /**
-     * 获取red tab节点 - 新方案
+ * Get Red tab node - new approach
      * */
     fun getRedBottomTabByText(text: String): AccessibilityNodeInfo? {
         AMNodeUtils.getAllNodeById(
@@ -108,12 +108,12 @@ internal object AMRedPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取返回节点
+ * Get back node
      * */
     fun getBackNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
         var nodeInfo: AccessibilityNodeInfo? = null
-        //返回节点id
+        //Back node id
         nodeInfo =
             AMNodeUtils.getFirstNodeByIdWithCallback(rootNode, object :
                 MatchCallback<AccessibilityNodeInfo> {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/tk/AMTkPageEvent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/tk/AMTkPageEvent.kt
@@ -18,7 +18,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 internal object AMTkPageEvent : IAMPageEvent() {
 
     /**
-     * 回到抖音首页
+ * Return to Douyin home page
      * */
     fun backTKHomePage(callBack: IAMTaskCallBack, helper: AMBaseStepHelper? = null) {
         AMEventUtils.doSomethingUntilSuccess(
@@ -76,7 +76,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在抖音首页
+ * Whether on Douyin home page
      */
     fun isInTkHomePage(name: String = "首页"): Boolean {
         AMCore.instance.amContext?.rootNode() ?: return false
@@ -90,7 +90,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 回到抖音会话
+ * Return to Douyin conversation
      * */
     fun backTKChatListPage(callBack: IAMTaskCallBack, helper: AMBaseStepHelper? = null) {
         AMEventUtils.doSomethingUntilSuccess(
@@ -149,7 +149,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在抖音会话列表
+ * Whether on the Douyin conversation list
      */
     fun isInTkChatListPage(name: String = "消息"): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -165,7 +165,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取tk tab节点 - 新方案
+ * Get tk tab node - new approach
      * */
     fun getTKBottomTabByText(text: String): AccessibilityNodeInfo? {
         AMNodeUtils.getAllNodeById(
@@ -181,7 +181,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取主页搜索节点
+ * Get home search node
      * */
     fun getMainSearchNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
@@ -198,7 +198,7 @@ internal object AMTkPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取消息列表搜索节点
+ * Get message-list search node
      * */
     fun getMsgSearchNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
@@ -216,12 +216,12 @@ internal object AMTkPageEvent : IAMPageEvent() {
 
 
     /**
-     * 获取返回节点
+ * Get back node
      * */
     fun getBackNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
         var nodeInfo: AccessibilityNodeInfo? = null
-        //返回节点id
+        //Back node id
         nodeInfo =
             AMNodeUtils.getFirstNodeByIdWithCallback(rootNode, object :
                 MatchCallback<AccessibilityNodeInfo> {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/wx/AMWxPageEvent.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/event/wx/AMWxPageEvent.kt
@@ -24,24 +24,24 @@ import com.coremate.opengui.automation.biz.common.event.IAMPageEvent
 import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 
 /**
- * 微信的事件
+ * We Chat events
  * */
 internal object AMWxPageEvent : IAMPageEvent() {
 
     /**
-     * 获取返回节点
+ * Get back node
      * */
     fun getBackNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
         var nodeInfo: AccessibilityNodeInfo? = null
-        //返回节点id
+        //Back node id
         nodeInfo =
             AMNodeUtils.getFirstNodeById(rootNode, IAMWidgetWX.globalBack().resourceId)
         return nodeInfo
     }
 
     /**
-     * 获取wx tab节点 - 新方案
+ * Get We Chat tab node - new approach
      * */
     fun getWxBottomTabByText(text: String): AccessibilityNodeInfo? {
         AMNodeUtils.getAllNodeById(
@@ -59,7 +59,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取微信发现列表
+ * Get We Chat Discover list
      * */
     fun getWeChatDiscoverListView(rootNode: AccessibilityNodeInfo?): List<AccessibilityNodeInfo>? {
         if (rootNode == null) return null
@@ -72,7 +72,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在微信首页
+ * Whether on We Chat home page
      */
     fun isInWeChatHomePage(name: String = "微信"): Boolean {
         AMCore.instance.amContext?.rootNode() ?: return false
@@ -94,7 +94,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取主页搜索节点
+ * Get home search node
      * */
     fun getMainSearchNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
@@ -107,7 +107,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取主页更多节点
+ * Get home more node
      * */
     fun getMainMoreNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
@@ -119,7 +119,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在设置页面
+ * Whether on the settings page
      * */
     fun isInSettingPage(): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -130,7 +130,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在通用页面
+ * Whether on the General page
      * */
     fun isInCurrencyPage(): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -147,7 +147,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 是否在辅助功能
+ * Whether on the Accessibility page
      * */
     fun isInHelperPage(): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -164,7 +164,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 好友详情右上角三个点
+ * Top-right three-dot menu on friend details
      */
     private fun getFriendDetailMoreNode(): AccessibilityNodeInfo? {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return null
@@ -173,7 +173,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
 
 
     /**
-     * 是否在朋友圈页面
+ * Whether on the Moments page
      * */
     fun isInFriendMomentsPage(): Boolean {
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return false
@@ -186,12 +186,12 @@ internal object AMWxPageEvent : IAMPageEvent() {
 
 
     /**
-     * 获取朋友圈列表节点
+ * Get Moments list node
      * */
     fun getMoments(): MutableList<AccessibilityNodeInfo> {
         val list = mutableListOf<AccessibilityNodeInfo>()
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return list
-        //页面listview
+        //Page List View
         var listNode =
             AMNodeUtils.getNodeByClassName(rootNode, ListView::class.java.name)
         if (listNode == null) {
@@ -211,7 +211,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 返回朋友圈页面
+ * Return to Moments page
      * */
     fun back2MomentAndHomePage(helper: AMBaseStepHelper): SomethingEvent {
 
@@ -257,7 +257,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 跳转朋友圈
+ * Navigate to Moments
      * */
     fun comeToFriendMoments(
         helper: AMBaseStepHelper,
@@ -373,7 +373,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 回到微信首页
+ * Return to We Chat home page
      * */
     fun back2WeChatHomePage(callBack: IAMTaskCallBack, helper: AMBaseStepHelper? = null) {
         AMEventUtils.doSomethingUntilSuccess(
@@ -431,7 +431,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 返回
+ * Back
      * */
     fun simpleBack(helper: AMBaseStepHelper? = null) {
         if (!isInTargetApp(AMTargetApp.WX)) return
@@ -445,7 +445,7 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取朋友圈列表文案 - 点赞使用
+ * Get Moments list text for likes
      * */
     fun getMomentTextFromMomentByLike(
         paramAccessibilityNodeInfo: AccessibilityNodeInfo
@@ -474,12 +474,12 @@ internal object AMWxPageEvent : IAMPageEvent() {
     }
 
     /**
-     * 获取朋友圈列表节点2
+ * Get Moments list node 2
      * */
     fun getMoments2(): MutableList<AccessibilityNodeInfo> {
         val list = mutableListOf<AccessibilityNodeInfo>()
         val rootNode = AMCore.instance.amContext?.rootNode() ?: return list
-        //页面listview
+        //Page List View
         var listNode =
             AMNodeUtils.getNodeByClassName(rootNode, ListView::class.java.name)
         if (listNode == null) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/float/EnterFloat.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/float/EnterFloat.kt
@@ -14,7 +14,7 @@ import com.coremate.opengui.automation.base.utils.AMScreenUtils
 import com.coremate.opengui.automation.databinding.CompEnterBinding
 
 /**
- * 进入弹窗 (主动弹窗)
+ * Enter dialog (active dialog)
  * */
 class EnterFloat(context: Context) : AMBaseFloatWindow<CompEnterBinding, EnterRepository>(context),
     AMTaskChangedListener {
@@ -59,14 +59,14 @@ class EnterFloat(context: Context) : AMBaseFloatWindow<CompEnterBinding, EnterRe
 
         amContext.taskManager.listener = this
 
-        //结束
+        //End
         binding.llStop.setOnClickListener {
             if (isLoading) return@setOnClickListener
             isStopLoading = true
             listener?.onStopComp()
         }
 
-        //暂停/开始
+        //Pause/Start
         binding.llControl.setOnClickListener {
             if (isLoading) return@setOnClickListener
             isLoading = true

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/float/EnterRepository.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/float/EnterRepository.kt
@@ -4,7 +4,7 @@ import com.coremate.opengui.automation.base.component.AMCompRepository
 import com.coremate.opengui.automation.base.utils.AMScreenUtils
 
 class EnterRepository : AMCompRepository() {
-    //初始坐标
+    //Initial coordinates
     override var startX = AMScreenUtils.screenWidth() / 2 - AMScreenUtils.dp2px(10f)
     override var startY =
         AMScreenUtils.screenHeight() - AMScreenUtils.dp2px(160f + 49f) - AMScreenUtils.getStatusBarHeight()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/foreground/AMForegroundService.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/foreground/AMForegroundService.kt
@@ -30,7 +30,7 @@ class AMForegroundService : Service() {
         val pendingIntent =
             PendingIntent.getActivity(this, 0, launchIntent, PendingIntent.FLAG_IMMUTABLE)
 
-        //TODO:8.0以上增加频道
+        //TODO: add channel support on Android 8.0+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val b = NotificationChannel(
                 CHANNEL_ID + noticeId,
@@ -43,19 +43,19 @@ class AMForegroundService : Service() {
         }
         val title = "Promotor"
         val mBuilder = NotificationCompat.Builder(this, CHANNEL_ID + noticeId)
-        mBuilder.setContentTitle(title) //设置通知栏标题
+        mBuilder.setContentTitle(title) // Set notification title.
             .setContentText("")
             .setContentIntent(pendingIntent)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
-            .setNumber(0) //设置通知集合的数量
+            .setNumber(0) // Set notification collection count.
             .setSound(null)
             .setSmallIcon(
                 AMServiceManager.instance.notificationImg ?: R.drawable.notification_small_icon
             )
             .setLights(0, 0, 0)
-            .setTicker(title) //通知首次出现在通知栏，带上升动画效果的
-            .setWhen(System.currentTimeMillis()) //通知产生的时间，会在通知信息里显示，一般是系统获取到的时间
+            .setTicker(title) // First ticker text shown with the notification animation.
+            .setWhen(System.currentTimeMillis()) // Notification creation time shown in notification details.
             .setVibrate(longArrayOf(0L))
         try {
             startForeground(noticeId, mBuilder.build())

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/lv/IAMWidgetLV.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/lv/IAMWidgetLV.kt
@@ -3,17 +3,17 @@ package com.coremate.opengui.automation.biz.common.node.lv
 import com.coremate.opengui.automation.biz.common.node.NodeWidgetBean
 
 /**
- * 剪映的节点组件
+ * Jianying node components
  * */
 object IAMWidgetLV {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    全局
+    // Global
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //全局/返回按钮 1
+    //Global/back button 1
     fun globalBack() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/ivBack",
@@ -24,11 +24,11 @@ object IAMWidgetLV {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    底部导航
+    // Bottom navigation
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //tab底部home按钮 *
+    //tabbottomhome Button *
     fun homeTabItem() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/radio_tab_home"
@@ -37,18 +37,18 @@ object IAMWidgetLV {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    首页
+    // Home page
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //首页热门首次进入的工具列表
+    //Home hot tool list on first entry
     fun homeToolsFirstGridView() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tool_recycler_view"
         ), "android.widget.GridView", "", ""
     )
 
-    //首页热门进入的工具列表
+    //Home hot tool list after entry
     fun homeToolsGridView() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tool_first_level_rv"
@@ -57,18 +57,18 @@ object IAMWidgetLV {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    营销视频功能内部
+    // Inside marketing video feature
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //营销视频
+    //Marketing video
     fun mixMarketingFirstVideos() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/home_tool_tv"
         ), "android.widget.TextView", "营销成片", ""
     )
 
-    //营销视频按钮
+    //Marketing video button
     fun mixMarketingVideos() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tool_item_title"
@@ -76,91 +76,91 @@ object IAMWidgetLV {
     )
 
 
-    //使用AI功能的确定按钮或其他确定按钮
+    //Confirm button for AI feature or other confirmation button
     fun mixAiCommitBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/btnPositive"
         ), "android.widget.Button", "确认", ""
     )
 
-    //选择素材，即可快速生成视频，取试试按钮
+    //Select materials to quickly generate a video, then use the Try button
     fun mixTryGoEditBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/go_edit"
         ), "android.widget.Button", "去试试", ""
     )
 
-    //素材viewpage
+    //Material View Pager
     fun mixVideoViewPager() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/gallery_list_pager2"
         ), "androidx.viewpager.widget.ViewPager", "", ""
     )
 
-    //素材列表
+    //Material list
     fun mixVideoViewGridList() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/local_media_recycler_view"
         ), "android.widget.GridView", "", ""
     )
 
-    //每一个素材选择按钮
+    //Selection button for each material
     fun mixVideoItemSelBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/iv_local_multi_media_select_index"
         ), "android.widget.TextView", "", ""
     )
 
-    //下一步按钮
+    //Next button
     fun mixMarketingVideoNext() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/sb_media_select_done"
         ), "android.widget.Button", "下一步", ""
     )
 
-    //商品门店信息
+    //Product/store information
     fun mixLynxTextAreaView() = NodeWidgetBean(
         mutableListOf(
             ""
         ), "com.bytedance.ies.xelement.input.LynxTextAreaView", "", ""
     )
 
-    //生成中的loading
+    //Generating loading state
     fun mixStartLoadingTv() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/loading_msg"
         ), "android.widget.TextView", "", ""
     )
 
-    //开始生成按钮
+    //Start generation button
     fun mixStartMixBtn() = NodeWidgetBean(
         mutableListOf(
             ""
         ), "com.lynx.tasm.behavior.ui.text.FlattenUIText", "开始生成", ""
     )
 
-    //合成进度
+    //Composition progress
     fun mixStartProgressTv() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tvProgress"
         ), "android.widget.TextView", "", ""
     )
 
-    //努力导出中loading
+    //Exporting loading state
     fun mixExportLoading() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/main_title"
         ), "android.widget.TextView", "努力导出中...", ""
     )
 
-    //导出按钮
+    //Export button
     fun mixStartExportTv() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/ivExport"
         ), "android.widget.TextView", "导出", ""
     )
 
-    //导出并分享
+    //Export and share
     fun mixStartExportBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tv_shareAweme"
@@ -170,18 +170,18 @@ object IAMWidgetLV {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    AI故事按钮功能内部
+    // AI story button inside feature
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //AI故事按钮
+    //AI story button
     fun marketingFirstVideos() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/home_tool_tv"
         ), "android.widget.TextView", "AI 故事成片", ""
     )
 
-    //AI故事按钮
+    //AI story button
     fun marketingVideos() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tool_item_title"
@@ -189,35 +189,35 @@ object IAMWidgetLV {
     )
 
 
-    //功能升级提示-我知道了
+    //Feature upgrade prompt: Got it
     fun funcUpKnow() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/btn_got_it"
         ), "android.widget.Button", "我知道了", ""
     )
 
-    //AI生成
+    //AI Generate
     fun aiCreate() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/content_ai"
         ), "android.widget.TextView", "AI 生成", ""
     )
 
-    //ai文字输入框
+    //AI text input field
     fun aiInput() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/vet_lui_input_content"
         ), "android.widget.EditText", "说说你的想法吧", ""
     )
 
-    //ai文字输入发送
+    //Send AI text input
     fun aiInputSend() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/iv_lui_input_send"
         ), "android.widget.ImageView", "", ""
     )
 
-    //ai内容插入
+    //Insert AI content
     fun aiInputInsert() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/vtv_lui_bottom_tool_insert"
@@ -225,49 +225,49 @@ object IAMWidgetLV {
     )
 
 
-    //应用
+    //App
     fun makeAiVideo() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/btn_finish"
         ), "android.widget.TextView", "应用", ""
     )
 
-    //开始生成按钮
+    //Start generation button
     fun startBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/generate_video_btn"
         ), "android.view.ViewGroup", "", ""
     )
 
-    //确定使用积分消耗
+    //Confirm point usage
     fun startBtnConfirm() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/btn_confirm"
         ), "android.widget.Button", "确认使用", ""
     )
 
-    //生成中的loading
+    //Generating loading state
     fun startLoadingTv() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tvBottomContext"
         ), "android.widget.TextView", "视频生成中", ""
     )
 
-    //导出按钮
+    //Export button
     fun startExportTv() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tvExport"
         ), "android.widget.Button", "导出", ""
     )
 
-    //弹窗的关闭按钮
+    //Dialog close button
     fun exportDialogClose() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/market_feedback_dialog_close"
         ), "android.widget.Button", "", ""
     )
 
-    //导出并分享
+    //Export and share
     fun startExportBtn() = NodeWidgetBean(
         mutableListOf(
             "com.lemon.lv:id/tv_share_aweme_v2"
@@ -275,7 +275,7 @@ object IAMWidgetLV {
     )
 
 
-    //打开第三方app的按钮
+    //Open third-party app button
     fun startThirdAppBtn() = NodeWidgetBean(
         mutableListOf(
             "android:id/button1"

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/red/IAMWidgetRed.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/red/IAMWidgetRed.kt
@@ -3,17 +3,17 @@ package com.coremate.opengui.automation.biz.common.node.red
 import com.coremate.opengui.automation.biz.common.node.NodeWidgetBean
 
 /**
- * 小红书的节点组件
+ * Xiaohongshu node components
  * */
 object IAMWidgetRed {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    全局
+    // Global
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //全局/返回按钮 1
+    //Global/back button 1
     fun globalBack() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/a2i",
@@ -23,18 +23,18 @@ object IAMWidgetRed {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    底部导航
+    // Bottom navigation
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //tab底部item的父容器 *
+    //tabbottomitemparent container *
     fun indexTabItem() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/igz"
         ), "android.widget.TextView", "", ""
     )
 
-    //tab底部item/未读消息
+    //tab Bottom item/unread messages
     fun unReadText() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/gbi"
@@ -43,18 +43,18 @@ object IAMWidgetRed {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    消息列表
+    // Message list
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    ///消息列表/顶部右边群聊按钮
+    ///Message list/top-right group chat button
     fun msgGroupbtn() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/fmq"
         ), "android.widget.TextView", "", "发现群聊"
     )
 
-    ///消息列表/数字红点
+    ///Message list/numbered red dot
     fun messageNumRedItem() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/ce2"
@@ -67,14 +67,14 @@ object IAMWidgetRed {
         ), "android.widget.TextView", "", ""
     )
 
-    ///消息列表/列表
+    ///Message list/list
     fun msgList() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/fqk"
         ), "androidx.recyclerview.widget.RecyclerView", "", ""
     )
 
-    ///消息列表/好友昵称
+    ///Message list/friend nickname
     fun contactNickName() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/fqh"
@@ -84,25 +84,25 @@ object IAMWidgetRed {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    消息
+    // Message
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //聊天页面/会话列表 *
+    //Chat page/conversation list *
     fun chatList() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/az4"
         ), "androidx.recyclerview.widget.RecyclerView", "", ""
     )
 
-    //聊天页面/最后一条消息内容
+    //Chat page/last message content
     fun lastMessage() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/ayd"
         ), "android.widget.TextView", "", ""
     )
 
-    //聊天页面/发送按钮
+    //Chat page/send button
     fun sendBtn() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/ayy"
@@ -115,7 +115,7 @@ object IAMWidgetRed {
         ), "android.widget.EditText", "", ""
     )
 
-    //你可能感兴趣的人
+    //People you may be interested in
     fun likeManNode() = NodeWidgetBean(
         mutableListOf(
             "com.xingin.xhs:id/fth"

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/tk/IAMWidgetTK.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/tk/IAMWidgetTK.kt
@@ -3,24 +3,24 @@ package com.coremate.opengui.automation.biz.common.node.tk
 import com.coremate.opengui.automation.biz.common.node.NodeWidgetBean
 
 /**
- * 抖音的节点组件
+ * Douyin node components
  * */
 object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    全局
+    // Global
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //全局loading *
+    //Global loading *
     fun loading() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/emz"
         ), "android.widget.RelativeLayout", "", ""
     )
 
-    //全局/返回 *
+    //Global/back *
     fun backBtn() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/back_btn"
@@ -29,11 +29,11 @@ object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    主页
+    // Home
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //主页/搜索 *
+    //Home/search *
     fun mainSearchBtn() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/obj"
@@ -42,18 +42,18 @@ object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    底部导航
+    // Bottom navigation
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //tab底部item的父容器 *
+    //tabbottomitemparent container *
     fun indexTabItem() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/n6t"
         ), "android.widget.TextView", "", ""
     )
 
-    //tab底部item/未读消息
+    //tab Bottom item/unread messages
     fun unReadText() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/nt="
@@ -62,18 +62,18 @@ object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    消息列表
+    // Message list
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    ///消息列表/顶部搜索
+    ///Message list/top search
     fun msgSearchBtn() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/gwd"
         ), "android.widget.Button", "", "搜索"
     )
 
-    ///消息列表/列表
+    ///Message list/list
     fun msgList() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/mp4"
@@ -81,14 +81,14 @@ object IAMWidgetTK {
     )
 
 
-    ///消息列表/好友昵称
+    ///Message list/friend nickname
     fun contactNickName() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/tv_title"
         ), "android.widget.TextView", "", ""
     )
 
-    ///消息列表/数字红点
+    ///Message list/numbered red dot
     fun messageNumRedItem() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/red_tips_count_view"
@@ -101,7 +101,7 @@ object IAMWidgetTK {
         ), "android.widget.TextView", "", ""
     )
 
-    ///消息列表/红点
+    ///Message list/red dot
     fun messageRedItem() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/g76"
@@ -111,39 +111,39 @@ object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    发布页面
+    // Publish page
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //聊天页面/返回 *
+    //Chat page/back *
     fun chatBackBtn() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/hf0"
         ), "android.widget.FrameLayout", "", ""
     )
 
-    //聊天页面/列表 *
+    //Chat page/list *
     fun chatList() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/lnn"
         ), "androidx.recyclerview.widget.RecyclerView", "", ""
     )
 
-    //聊天页面/文字内容
+    //Chat page/text content
     fun chatContent() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/content_layout"
         ), "android.widget.TextView", "", ""
     )
 
-    //聊天页面/底部输入框
+    //Chat page/bottom input field
     fun chatEdit() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/msg_et"
         ), "android.widget.EditText", "", ""
     )
 
-    //聊天页面/发送按钮
+    //Chat page/send button
     fun chatSend() = NodeWidgetBean(
         mutableListOf(
             "com.ss.android.ugc.aweme:id/fz-"
@@ -153,11 +153,11 @@ object IAMWidgetTK {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    发布页面
+    // Publish page
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //下一步
+    //Next step
     fun nextBtn() = NodeWidgetBean(
         mutableListOf(
             "m.l.plugin.tools_plugin:id/fl_next_step",
@@ -165,7 +165,7 @@ object IAMWidgetTK {
         ), "android.widget.TextView", "下一步", ""
     )
 
-    //发布
+    //Publish
     fun publishBtn() = NodeWidgetBean(
         mutableListOf(
             "m.l.plugin.tools_plugin:id/publish_txt"

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/wx/IAMWidgetWX.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/common/node/wx/IAMWidgetWX.kt
@@ -3,17 +3,17 @@ package com.coremate.opengui.automation.biz.common.node.wx
 import com.coremate.opengui.automation.biz.common.node.NodeWidgetBean
 
 /**
- * 微信的节点组件
+ * We Chat node components
  * */
 object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                     全局
+    // Global
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //全局/返回按钮 1
+    //Global/back button 1
     fun globalBack() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/a4p",
@@ -23,25 +23,25 @@ object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    微信首页
+    // We Chat home
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //微信首页/搜索 1
+    //We Chat home/search 1
     fun mainSearch() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/jha"
         ), "android.widget.RelativeLayout", "", "搜索"
     )
 
-    //微信首页/更多 1
+    //We Chat home/more 1
     fun mainMore() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/jga"
         ), "android.widget.RelativeLayout", "", "更多功能按钮"
     )
 
-    //微信首页/最近
+    //We Chat home/recent
     fun topTitle() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/wp"
@@ -52,18 +52,18 @@ object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    底部导航
+    // Bottom navigation
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //tab底部item的父容器 *
+    //tabbottomitemparent container *
     fun indexTabItem() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/nvt"
         ), "android.widget.RelativeLayout", "", ""
     )
 
-    //tab底部item/未读消息
+    //tab Bottom item/unread messages
     fun unReadText() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/osw"
@@ -72,25 +72,25 @@ object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    消息
+    // Message
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    ///消息列表/item
+    ///Message list/item
     fun messageListItem() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/cj1"
         ), "android.widget.LinearLayout", "", ""
     )
 
-    ///消息列表/好友昵称
+    ///Message list/friend nickname
     fun contactNickName() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/kbq"
         ), "android.widget.TextView", "", ""
     )
 
-    ///消息列表/数字红点
+    ///Message list/numbered red dot
     fun messageNumRedItem() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/o_u"
@@ -99,25 +99,25 @@ object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    聊天页面
+    // Chat page
     //
     /////////////////////////////////////////////////////////////////////////////////
 
-    //聊天页面/会话列表 *
+    //Chat page/conversation list *
     fun chatList() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/bp0"
         ), "androidx.recyclerview.widget.RecyclerView", "", ""
     )
 
-    //聊天页面/最后一条消息内容
+    //Chat page/last message content
     fun lastMessage() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/bkl"
         ), "android.widget.TextView", "", ""
     )
 
-    //聊天页面/发送按钮
+    //Chat page/send button
     fun sendBtn() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/bql"
@@ -127,26 +127,26 @@ object IAMWidgetWX {
 
     /////////////////////////////////////////////////////////////////////////////////
     //
-    //                    朋友圈
+    // Moments
     //
     /////////////////////////////////////////////////////////////////////////////////
 
 
-    //朋友圈用户名
+    //Moments username
     fun fcListUserName() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/kbq"
         ), "android.widget.TextView", "", ""
     )
 
-    //朋友圈/列表图片集合
+    //Moments/list image set
     fun fcListImages() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/n96"
         ), "", "", ""
     )
 
-    //朋友圈/评论输入框
+    //Moments/comment input field
     fun fcListCommentEdit() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/p0"
@@ -160,7 +160,7 @@ object IAMWidgetWX {
     )
 
 
-    //更多按钮
+    //more Button
     fun fcMoreBtn() = NodeWidgetBean(
         mutableListOf(
             "com.tencent.mm:id/r2"

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/permission/AMPermissionDialog.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/permission/AMPermissionDialog.kt
@@ -45,10 +45,10 @@ class AMPermissionDialog(val dContext: Context) : Dialog(dContext, R.style.MyDia
     }
 
     /**
-     * 更新UI
-     * 1、初始化调用
-     * 3、悬浮权限回调调用
-     * 4、辅助权限回调调用
+ * Update UI
+ * 1. called during initialization
+ * 3. called by floating-window permission callback
+ * 4. called by accessibility permission callback
      * */
     fun updateUIOrFinish(isCheckFinish: Boolean) {
         changeBtnState(binding.tvFloatBt, floatPermission)
@@ -63,7 +63,7 @@ class AMPermissionDialog(val dContext: Context) : Dialog(dContext, R.style.MyDia
     }
 
     /**
-     * 事件
+ * Event
      * */
     private fun initEvent() {
         binding.ivClose.setOnClickListener {
@@ -87,7 +87,7 @@ class AMPermissionDialog(val dContext: Context) : Dialog(dContext, R.style.MyDia
     }
 
     /**
-     * 更改按钮状态
+ * Change button state
      * */
     private fun changeBtnState(textView: TextView, isHasPermission: Boolean) {
         textView.apply {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/AMCommonAutoReplyHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/AMCommonAutoReplyHelper.kt
@@ -32,7 +32,7 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
         AMTargetApp.RED,
     );
 
-    ///监控app的索引
+    ///Index of monitored app
     @Volatile
     private var appIndex = 0
 
@@ -41,16 +41,16 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
 
     private val appCount = apps.size
 
-    //是否在回复中
+    //Whether replying
     @Volatile
     private var setReplying = false
 
-    //获取任务状态
+    //Get task status
     val isReplying: Boolean
         get() = setReplying
 
     /**
-     * 设置是否是正在回复中的状态
+ * Set whether currently replying
      */
     fun setReplying(replying: Boolean) {
         synchronized(this) {
@@ -58,13 +58,13 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
         }
     }
 
-    //标记完成
+    //Mark complete
     var isHasFinish = false
 
-    //间隔时间（分钟）
+    //Interval in minutes
     private var cutDownTime = 0
 
-    ///计时监测
+    ///Timed monitor
     private val mCheckDelayTime: Long = 1000 * 60
     private var mCheckTimer: Timer? = null
     private var mCheckTimerTask: BroadcastTimerTask? = null
@@ -106,9 +106,9 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
             AMTkAutoReplyStep7::class,
         )
         startTime = System.currentTimeMillis()
-        // 开启监测
+        // Start monitoring
         startTimer()
-        //开始执行
+        //Start execution
         continueApp()
     }
 
@@ -132,7 +132,7 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
         }
     }
 
-    ///开始计时
+    ///Start timer
     private fun startTimer() {
         if (mCheckTimer == null) {
             mCheckTimer = Timer()
@@ -142,7 +142,7 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
         }
     }
 
-    ///取消计时
+    ///Cancel timer
     private fun cancelTimer() {
         mCheckTimer?.cancel()
         mCheckTimer = null
@@ -151,22 +151,22 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
     }
 
 
-    //倒计时
+    //Countdown
     private inner class BroadcastTimerTask : TimerTask() {
         override fun run() {
             if (isTaskPauseOrStop()) return
             if (isCurrentTimeAfter(param?.endTime ?: "")) {
                 AMLog.onEDebugLog("结束监测")
-                //结束了
+                //Ended
                 cancelTimer()
-                //停止掉
+                //Stop it
                 wxHelper.onTemporarySuspension()
                 tkHelper.onTemporarySuspension()
                 redHelper.onTemporarySuspension()
-                //标记完成
+                //Mark complete
                 isHasFinish = true
                 if (!isReplying) {
-                    //完成
+                    //Complete
                     amContext.processListener?.onProcessTaskFinish(
                         true,
                         System.currentTimeMillis() - startTime,
@@ -177,14 +177,14 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
                 cutDownTime--
                 if (cutDownTime <= 0) {
                     if (isReplying) {
-                        //正在回复的时候，继续倒计时
+                        //Continue countdown while replying
                         cutDownTime++
                     } else {
-                        //停止掉
+                        //Stop it
                         wxHelper.onTemporarySuspension()
                         tkHelper.onTemporarySuspension()
                         redHelper.onTemporarySuspension()
-                        //继续下一个app
+                        //Continue to the next app
                         cutDownTime = param?.interval ?: 10
                         appIndex = (appIndex + 1) % appCount
                         curApp = apps[appIndex]
@@ -227,7 +227,7 @@ internal class AMCommonAutoReplyHelper : AMBaseStepHelper() {
         }
     }
 
-    //是否超过结束时间
+    //Whether past the end time
     private fun isCurrentTimeAfter(endTimeStr: String): Boolean {
         return try {
             val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/AMCommonAutoReplyTask.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/AMCommonAutoReplyTask.kt
@@ -19,11 +19,11 @@ internal class AMCommonAutoReplyTask(amContext: AMContext) :
 
 
     override fun initTaskAndData(dataContainer: AMDataContainer?) {
-        //弹出悬浮窗
+        //Show floating window
         amContext.componentManager?.onExecute(AMCompModel(compCls = EnterFloat::class))
-        //设置数据
+        //Set data
         helper.param = dataContainer?.bean as AMCommonAutoReplyParam
-        //设置子helper
+        //Set child helper
         helper.initSub()
 
     }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/bean/AMCommonAutoReplyParam.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/bean/AMCommonAutoReplyParam.kt
@@ -1,9 +1,9 @@
 package com.coremate.opengui.automation.biz.tasks.common.check.bean
 
 data class AMCommonAutoReplyParam(
-    //结束时间
+    //End time
     var endTime: String? = null,
-    //间隔多久切换平台监测(默认10分钟)
+    //Interval duration Switch-platform monitor, default 10 minutes
     var interval: Int = 10
 
 )

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/AMCommonAutoListener.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/AMCommonAutoListener.kt
@@ -5,9 +5,9 @@ import com.coremate.opengui.automation.biz.tasks.common.check.AMCommonAutoReplyH
 internal interface AMCommonAutoListener {
 
     fun bindCommon(helper: AMCommonAutoReplyHelper)
-    //继续
+    //Continue
     fun onContinue()
-    //暂时停止
+    //Temporarily stop
     fun onTemporarySuspension()
 
 }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/AMRedAutoReplyHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/AMRedAutoReplyHelper.kt
@@ -12,7 +12,7 @@ internal class AMRedAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
     var commonHelper: AMCommonAutoReplyHelper? = null
     var param: AMCommonAutoReplyParam? = null
 
-    ///是否暂时停止
+    ///whether Temporarily stop
     var isTemporary = false
 
     var tempNodeList = mutableListOf<AccessibilityNodeInfo>()
@@ -20,7 +20,7 @@ internal class AMRedAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
     var nickName = ""
     var replyContent = ""
 
-    ///是否是当前app
+    ///Whether this is the current app
     fun isOngoing() = (commonHelper?.curApp == AMTargetApp.RED || !isTemporary)
 
 

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep1.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.event.red.AMRedPageEvent
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第1步：跳转到小红书会话页面
+ * Step 1: Navigate to the Xiaohongshu conversation page
  */
 internal class AMRedAutoReplyStep1(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
@@ -27,14 +27,14 @@ internal class AMRedAutoReplyStep1(index: Int, helper: AMRedAutoReplyHelper) :
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
         }
         SelectToSpeakService.service?.changeAccessibilityFlags(false)
-        //判断返回的小红书消息列表
+        //Check Back Xiaohongshu Message list
         AMRedPageEvent.backRedChatListPage(object : IAMPageEvent.IAMTaskCallBack {
             override fun action(): Boolean {
                 return helper.isTaskPauseOrStop() || !helper.isOngoing()
             }
         }, helper)
 
-        //判断是否在会话列表
+        //Check whether on the conversation list
         if (!AMRedPageEvent.isInRedChatListPage()) {
             throw AMTaskException.business("不在小红书首页")
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep2.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第2步：监控微信未读消息数
+ * Step 2:Monitor We Chat unread count
  */
 internal class AMRedAutoReplyStep2(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
@@ -24,7 +24,7 @@ internal class AMRedAutoReplyStep2(index: Int, helper: AMRedAutoReplyHelper) :
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.commonHelper?.setReplying(false)
         if (helper.commonHelper?.isHasFinish == true) {
-            ///完成
+            ///Complete
             helper.commonHelper?.amContext?.processListener?.onProcessTaskFinish(
                 true,
                 System.currentTimeMillis() - (helper.commonHelper?.startTime ?: 0),

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep3.kt
@@ -18,12 +18,12 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第3步：遍历消息列表
+ * Step 3: Traverse the message list
  */
 internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
 
-    //已经加入的好友信息
+    //Already-added friend info
     private var alreadyAddFriends = mutableListOf<String>()
 
     override fun onExecute(data: AMDataContainer?, isResume: Boolean): AMStepCondition {
@@ -34,30 +34,30 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
 
         SelectToSpeakService.service?.changeAccessibilityFlags(true)
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //清空临时列表
+        //Clear temporary list
         alreadyAddFriends.clear()
         helper.tempNodeList.clear()
         while (true) {
             if (!helper.isOngoing() || helper.isTaskPauseOrStop()) {
                 return condition
             }
-            //根节点
+            //Root node
             var rootNode = AMCore.instance.amContext?.rootNode()
             if (rootNode == null) {
                 AMEventUtils.sleep(AMActionDelay.MIDDLE)
                 rootNode = AMCore.instance.amContext?.rootNode()
             }
-            //列表节点
+            //List node
             var listViewNode =
                 AMNodeUtils.getFirstNodeById(rootNode, IAMWidgetRed.msgList().resourceId)
                     ?: throw AMTaskException.business("列表为空")
 
-            ///是否要滑动到最顶部
+            ///Whether to swipe to the top
             var isNoCanSlide = false
             if (data?.extra is Boolean) {
                 isNoCanSlide = data.extra as Boolean
             }
-            //滑动到最顶部
+            //Swipe to the top
             while (true) {
                 if (!helper.isOngoing() || helper.isTaskPauseOrStop()) {
                     return condition
@@ -74,7 +74,7 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
             for (i in 0..<listViewNode.childCount) {
                 val tvNodeInfo = listViewNode.getChild(i)
                 if (i == 0 && tvNodeInfo.className.toString() == LinearLayout::class.java.name) {
-                    //过滤非红点的节点
+                    //Filter nodes without red dots
                     for (j in 0..<tvNodeInfo.childCount) {
                         val subNode = tvNodeInfo.getChild(j)
                         val numRedInfo = AMNodeUtils.getFirstNodeById(
@@ -82,29 +82,29 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
                             IAMWidgetRed.messageNumRedItem().resourceId
                         )
                         if (numRedInfo != null) {
-                            //过滤已经添加的节点
+                            //Filter already-added nodes
                             if (alreadyAddFriends.contains("topTab$j")) {
                                 continue
                             }
-                            //添加到总数组
+                            //Add to the main array
                             alreadyAddFriends.add("topTab$j")
-                            //添加到临时数组
+                            //Add to the temporary array
                             helper.tempNodeList.add(subNode)
                         }
                     }
                     continue
                 }
-                //1.判断节点是否为空
+                //1. Check whether the node is null
                 if (tvNodeInfo.className.toString() != RelativeLayout::class.java.name) continue
                 val nameInfo = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetRed.contactNickName().resourceId
                 )
-                //2.判断用户昵称是否为空 (name可能会重复,先忽略)
+                //2. Check whether the user nickname is empty; name may repeat, ignore for now
                 val name = nameInfo?.text.toString()
                 if (TextUtils.isEmpty(name)) continue
 
-                //3.过滤非红点的节点
+                //3.Filter nodes without red dots
                 val numRedInfo2 = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetRed.messageNumRedItem2().resourceId
@@ -113,17 +113,17 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
                 if (numRedInfo2 == null) {
                     continue
                 }
-                //4.过滤已经添加的节点
+                //4.Filter already-added nodes
                 if (alreadyAddFriends.contains(name)) {
                     continue
                 }
-                //添加到总数组
+                //Add to the main array
                 alreadyAddFriends.add(name)
-                //添加到临时数组
+                //Add to the temporary array
                 helper.tempNodeList.add(tvNodeInfo)
 
             }
-            //当临时列表不为空时，执行第4步
+            //Execute step 4 when the temporary list is not empty
             if (helper.tempNodeList.isNotEmpty()) {
                 helper.executorService.execute {
                     if (helper.isOngoing()) {
@@ -132,7 +132,7 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
                 }
                 return condition
             }
-            //滑动
+            //Swipe
             val manNode = AMNodeUtils.getFirstNodeById(
                 listViewNode,
                 IAMWidgetRed.likeManNode().resourceId
@@ -149,7 +149,7 @@ internal class AMRedAutoReplyStep3(index: Int, helper: AMRedAutoReplyHelper) :
             }
         }
 
-        ///回到第2步继续
+        ///Return to step 2 and continue
         helper.executorService.execute {
             if (helper.isOngoing()) {
                 helper.secondStep()?.onExecute()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep4.kt
@@ -14,7 +14,7 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第4步：分发子任务
+ * Step 4:Dispatch subtasks
  */
 internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
@@ -22,7 +22,7 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
     override val isDispatcher: Boolean
         get() = true
 
-    //记录循环过滤索引
+    //Record loop filter index
     private var tempIndex = 0
 
     init {
@@ -47,7 +47,7 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
             if (i >= tempIndex) {
                 val nodeInfo = helper.tempNodeList[i]
                 AMLog.onEDebugLog("当前子步骤${subStepIndex}")
-                //第5步 - 点击进入
+                //Step 5 - Tap to enter
                 if (subStepIndex == 5) {
                     val nameInfo = AMNodeUtils.getFirstNodeById(
                         nodeInfo,
@@ -66,7 +66,7 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
 
                 }
 
-                //第6步 - 传参数给AI，获取评论
+                //Step 6 - Pass parameters to AI and get comment
                 if (subStepIndex in 5..6 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -79,7 +79,7 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
                         }.second
                 }
 
-                //第7步 - 自动回复
+                //Step 7 - Auto-reply
                 if (subStepIndex in 5..7 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -92,7 +92,7 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
                         }.second
                 }
 
-                //回到消息列表
+                //Return to message list
                 AMRedPageEvent.backRedChatListPage(object : IAMPageEvent.IAMTaskCallBack {
                     override fun action(): Boolean {
                         return helper.isTaskPauseOrStop() || !helper.isOngoing()
@@ -101,13 +101,13 @@ internal class AMRedAutoReplyStep4(index: Int, helper: AMRedAutoReplyHelper) :
 
 
                 subStepIndex = 5
-                //增加过滤索引
+                //Increment filter index
                 tempIndex++
             }
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.executorService.execute {
-            //回到第3步
+            //Return to step 3
             tempIndex = 0
             AMLog.onEDebugLog("回到第3步")
             helper.thirdStep()?.onExecute(data = AMDataContainer().withExtra(true))

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep5.kt
@@ -10,7 +10,7 @@ import com.coremate.opengui.automation.base.utils.Something
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第5步：获取昵称并点击进入会话
+ * Step 5:Get nickname and tap into conversation
  */
 internal class AMRedAutoReplyStep5(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep6.kt
@@ -18,7 +18,7 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第6步：传参数给AI，获取评论
+ * Step 6:Pass parameters to AI and get comment
  */
 internal class AMRedAutoReplyStep6(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
@@ -34,7 +34,7 @@ internal class AMRedAutoReplyStep6(index: Int, helper: AMRedAutoReplyHelper) :
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //获取最后一条信息
+        //Get the last message
         var recyclerViewNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,
@@ -61,7 +61,7 @@ internal class AMRedAutoReplyStep6(index: Int, helper: AMRedAutoReplyHelper) :
             condition.isCanNext = false
             return condition
         }
-        //获取最后一个节点
+        //Get the last node
         val nodeList = mutableListOf<AccessibilityNodeInfo?>()
         for (i in 0..<(recyclerViewNode?.childCount ?: 0)) {
             val node = recyclerViewNode?.getChild(i)
@@ -86,7 +86,7 @@ internal class AMRedAutoReplyStep6(index: Int, helper: AMRedAutoReplyHelper) :
             }
         }
 
-        // 运行测试场景 2
+        // Run test scenario 2
         val mockChatPartnerNickname = helper.nickName
         val mockLastWeChatMessage = contentStr
         if (!helper.isOngoing()) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/red/steps/AMRedAutoReplyStep7.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.red.IAMWidgetRed
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.red.AMRedAutoReplyHelper
 
 /**
- * 第7步：自动回复
+ * Step 7:Auto-reply
  */
 internal class AMRedAutoReplyStep7(index: Int, helper: AMRedAutoReplyHelper) :
     AMBaseStep<AMRedAutoReplyHelper>(index, helper) {
@@ -29,7 +29,7 @@ internal class AMRedAutoReplyStep7(index: Int, helper: AMRedAutoReplyHelper) :
         }
 
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //输入框节点
+        //Input field node
         var editNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/AMTkAutoReplyHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/AMTkAutoReplyHelper.kt
@@ -19,7 +19,7 @@ internal class AMTkAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
     var nickName = ""
     var replyContent = ""
 
-    ///是否是当前app
+    ///Whether this is the current app
     fun isOngoing() = (commonHelper?.curApp == AMTargetApp.TK || !isTemporary)
 
     public override fun onObserveTaskResume() {
@@ -29,7 +29,7 @@ internal class AMTkAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
             }
 
             else -> {
-                //其他步骤全部在第4部中处理
+                //All other steps are handled in step 4
                 forthStep()?.onExecute(isResume = true)
             }
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep1.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.event.tk.AMTkPageEvent
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第1步：跳转到抖音会话页面
+ * Step 1:Navigate to Douyin conversation page
  */
 internal class AMTkAutoReplyStep1(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
@@ -27,14 +27,14 @@ internal class AMTkAutoReplyStep1(index: Int, helper: AMTkAutoReplyHelper) :
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
         }
         SelectToSpeakService.service?.changeAccessibilityFlags(false)
-        //判断返回的微信首页
+        //Check Back WeChat home
         AMTkPageEvent.backTKChatListPage(object : IAMPageEvent.IAMTaskCallBack {
             override fun action(): Boolean {
                 return helper.isTaskPauseOrStop() || !helper.isOngoing()
             }
         }, helper)
 
-        //判断是否在会话页面
+        //Check whether on the conversation page
         if (!AMTkPageEvent.isInTkChatListPage()) {
             throw AMTaskException.business("不在抖音首页")
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep2.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第2步：监控抖音未读消息数
+ * Step 2:Monitor Douyin unread count
  */
 internal class AMTkAutoReplyStep2(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
@@ -24,7 +24,7 @@ internal class AMTkAutoReplyStep2(index: Int, helper: AMTkAutoReplyHelper) :
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.commonHelper?.setReplying(false)
         if (helper.commonHelper?.isHasFinish == true) {
-            ///完成
+            ///Complete
             helper.commonHelper?.amContext?.processListener?.onProcessTaskFinish(
                 true,
                 System.currentTimeMillis() - (helper.commonHelper?.startTime ?: 0),

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep3.kt
@@ -18,12 +18,12 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第3步：遍历消息列表
+ * Step 3: Traverse the message list
  */
 internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
 
-    //已经加入的好友信息
+    //Already-added friend info
     private var alreadyAddFriends = mutableListOf<String>()
 
     override fun onExecute(data: AMDataContainer?, isResume: Boolean): AMStepCondition {
@@ -34,30 +34,30 @@ internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
 
         SelectToSpeakService.service?.changeAccessibilityFlags(true)
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //清空临时列表
+        //Clear temporary list
         alreadyAddFriends.clear()
         helper.tempNodeList.clear()
         while (true) {
             if (!helper.isOngoing() || helper.isTaskPauseOrStop()) {
                 return condition
             }
-            //根节点
+            //Root node
             var rootNode = AMCore.instance.amContext?.rootNode()
             if (rootNode == null) {
                 AMEventUtils.sleep(AMActionDelay.MIDDLE)
                 rootNode = AMCore.instance.amContext?.rootNode()
             }
-            //列表节点
+            //List node
             val listViewNode =
                 AMNodeUtils.getFirstNodeById(rootNode, IAMWidgetTK.msgList().resourceId)
                     ?: throw AMTaskException.business("列表为空")
 
-            ///是否要滑动到最顶部
+            ///Whether to swipe to the top
             var isNoCanSlide = false
             if (data?.extra is Boolean) {
                 isNoCanSlide = data.extra as Boolean
             }
-            //滑动到最顶部
+            //Swipe to the top
             while (true) {
                 if (!helper.isOngoing() || helper.isTaskPauseOrStop()) {
                     return condition
@@ -69,17 +69,17 @@ internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
 
             for (i in 0..<listViewNode.childCount) {
                 val tvNodeInfo = listViewNode.getChild(i)
-                //1.判断节点是否为空
+                //1. Check whether the node is null
                 if (tvNodeInfo.className.toString() != Button::class.java.name) continue
                 val nameInfo = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetTK.contactNickName().resourceId
                 )
-                //2.判断用户昵称是否为空 (name可能会重复,先忽略)
+                //2. Check whether the user nickname is empty; name may repeat, ignore for now
                 val name = nameInfo?.text.toString()
                 if (TextUtils.isEmpty(name)) continue
 
-                //3.过滤非红点的节点
+                //3.Filter nodes without red dots
                 val numRedInfo = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetTK.messageNumRedItem().resourceId
@@ -97,17 +97,17 @@ internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
                 if (numRedInfo == null && numRedInfo2 == null) {
                     continue
                 }
-                //4.过滤已经添加的节点
+                //4.Filter already-added nodes
                 if (alreadyAddFriends.contains(name)) {
                     continue
                 }
-                //添加到总数组
+                //Add to the main array
                 alreadyAddFriends.add(name)
-                //添加到临时数组
+                //Add to the temporary array
                 helper.tempNodeList.add(tvNodeInfo)
 
             }
-            //当临时列表不为空时，执行第4步
+            //Execute step 4 when the temporary list is not empty
             if (helper.tempNodeList.isNotEmpty()) {
                 helper.executorService.execute {
                     if (helper.isOngoing()) {
@@ -116,7 +116,7 @@ internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
                 }
                 return condition
             }
-            //滑动
+            //Swipe
             if (listViewNode.performAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD)) {
                 AMEventUtils.sleep(AMActionDelay.MIDDLE)
                 continue
@@ -126,7 +126,7 @@ internal class AMTkAutoReplyStep3(index: Int, helper: AMTkAutoReplyHelper) :
             }
         }
 
-        ///回到第2步继续
+        ///Return to step 2 and continue
         helper.executorService.execute {
             if (helper.isOngoing()) {
                 helper.secondStep()?.onExecute()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep4.kt
@@ -14,7 +14,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第4步：分发子任务
+ * Step 4:Dispatch subtasks
  */
 internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
@@ -22,7 +22,7 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
     override val isDispatcher: Boolean
         get() = true
 
-    //记录循环过滤索引
+    //Record loop filter index
     private var tempIndex = 0
 
     init {
@@ -47,7 +47,7 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
             if (i >= tempIndex) {
                 val nodeInfo = helper.tempNodeList[i]
                 AMLog.onEDebugLog("当前子步骤${subStepIndex}")
-                //第5步 - 点击进入
+                //Step 5 - Tap to enter
                 if (subStepIndex == 5) {
                     val nameInfo = AMNodeUtils.getFirstNodeById(
                         nodeInfo,
@@ -66,7 +66,7 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
 
                 }
 
-                //第6步 - 传参数给AI，获取评论
+                //Step 6 - Pass parameters to AI and get comment
                 if (subStepIndex in 5..6 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -79,7 +79,7 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
                         }.second
                 }
 
-                //第7步 - 自动回复
+                //Step 7 - Auto-reply
                 if (subStepIndex in 5..7 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -92,7 +92,7 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
                         }.second
                 }
 
-                //回到消息列表
+                //Return to message list
                 AMTkPageEvent.backTKChatListPage(object : IAMPageEvent.IAMTaskCallBack {
                     override fun action(): Boolean {
                         return helper.isTaskPauseOrStop() || !helper.isOngoing()
@@ -101,13 +101,13 @@ internal class AMTkAutoReplyStep4(index: Int, helper: AMTkAutoReplyHelper) :
 
 
                 subStepIndex = 5
-                //增加过滤索引
+                //Increment filter index
                 tempIndex++
             }
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.executorService.execute {
-            //回到第3步
+            //Return to step 3
             tempIndex = 0
             AMLog.onEDebugLog("回到第3步")
             helper.thirdStep()?.onExecute(data = AMDataContainer().withExtra(true))

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep5.kt
@@ -10,7 +10,7 @@ import com.coremate.opengui.automation.base.utils.Something
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第5步：获取昵称并点击进入会话
+ * Step 5:Get nickname and tap into conversation
  */
 internal class AMTkAutoReplyStep5(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep6.kt
@@ -18,7 +18,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第6步：传参数给AI，获取评论
+ * Step 6:Pass parameters to AI and get comment
  */
 internal class AMTkAutoReplyStep6(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
@@ -34,7 +34,7 @@ internal class AMTkAutoReplyStep6(index: Int, helper: AMTkAutoReplyHelper) :
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //获取最后一条信息
+        //Get the last message
         var recyclerViewNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,
@@ -61,7 +61,7 @@ internal class AMTkAutoReplyStep6(index: Int, helper: AMTkAutoReplyHelper) :
             condition.isCanNext = false
             return condition
         }
-        //获取最后一个节点
+        //Get the last node
         val nodeList = mutableListOf<AccessibilityNodeInfo?>()
         for (i in 0..<(recyclerViewNode?.childCount ?: 0)) {
             val node = recyclerViewNode?.getChild(i)
@@ -86,7 +86,7 @@ internal class AMTkAutoReplyStep6(index: Int, helper: AMTkAutoReplyHelper) :
             }
         }
 
-        // 运行测试场景 2
+        // Run test scenario 2
         val mockChatPartnerNickname = helper.nickName
         val mockLastWeChatMessage = contentStr
         if (!helper.isOngoing()) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/tk/steps/AMTkAutoReplyStep7.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.tk.AMTkAutoReplyHelper
 
 /**
- * 第7步：自动回复
+ * Step 7:Auto-reply
  */
 internal class AMTkAutoReplyStep7(index: Int, helper: AMTkAutoReplyHelper) :
     AMBaseStep<AMTkAutoReplyHelper>(index, helper) {
@@ -29,7 +29,7 @@ internal class AMTkAutoReplyStep7(index: Int, helper: AMTkAutoReplyHelper) :
         }
 
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //输入框节点
+        //Input field node
         var editNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/AMWxAutoReplyHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/AMWxAutoReplyHelper.kt
@@ -39,7 +39,7 @@ internal class AMWxAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
     var nickName = ""
     var replyContent = ""
 
-    ///是否是当前app
+    ///Whether this is the current app
     fun isOngoing() = (commonHelper?.curApp == AMTargetApp.WX || !isTemporary)
 
     override fun bindCommon(helper: AMCommonAutoReplyHelper) {
@@ -60,7 +60,7 @@ internal class AMWxAutoReplyHelper : AMBaseStepHelper(), AMCommonAutoListener {
             }
 
             else -> {
-                //其他步骤全部在第4部中处理
+                //All other steps are handled in step 4
                 forthStep()?.onExecute(isResume = true)
             }
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep1.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.event.wx.AMWxPageEvent
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第1步：跳转到微信首页(会话页面)
+ * Step 1: Navigate to WeChat home (conversation page)
  */
 internal class AMWxAutoReplyStep1(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
@@ -27,14 +27,14 @@ internal class AMWxAutoReplyStep1(index: Int, helper: AMWxAutoReplyHelper) :
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
         }
         SelectToSpeakService.service?.changeAccessibilityFlags(false)
-        //判断返回的微信首页
+        //Check Back WeChat home
         AMWxPageEvent.back2WeChatHomePage(object : IAMPageEvent.IAMTaskCallBack {
             override fun action(): Boolean {
                 return helper.isTaskPauseOrStop() || !helper.isOngoing()
             }
         }, helper)
 
-        //判断是否在微信首页
+        //Check Whether on We Chat home page
         if (!AMWxPageEvent.isInWeChatHomePage()) {
             throw AMTaskException.business("不在微信首页")
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep2.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第2步：监控微信未读消息数
+ * Step 2:Monitor We Chat unread count
  */
 internal class AMWxAutoReplyStep2(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
@@ -24,7 +24,7 @@ internal class AMWxAutoReplyStep2(index: Int, helper: AMWxAutoReplyHelper) :
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.commonHelper?.setReplying(false)
         if (helper.commonHelper?.isHasFinish == true) {
-            ///完成
+            ///Complete
             helper.commonHelper?.amContext?.processListener?.onProcessTaskFinish(
                 true,
                 System.currentTimeMillis() - (helper.commonHelper?.startTime ?: 0),

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep3.kt
@@ -17,12 +17,12 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第3步：遍历消息列表
+ * Step 3: Traverse the message list
  */
 internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
 
-    //已经加入的好友信息
+    //Already-added friend info
     private var alreadyAddFriends = mutableListOf<String>()
 
     override fun onExecute(data: AMDataContainer?, isResume: Boolean): AMStepCondition {
@@ -31,36 +31,36 @@ internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
             return condition
         }
 
-        //清空临时列表
+        //Clear temporary list
         alreadyAddFriends.clear()
         helper.tempNodeList.clear()
         while (true) {
             if (!helper.isOngoing() || helper.isTaskPauseOrStop()) {
                 return condition
             }
-            //根节点
+            //Root node
             var rootNode = AMCore.instance.amContext?.rootNode()
             if (rootNode == null) {
                 AMEventUtils.sleep(AMActionDelay.MIDDLE)
                 rootNode = AMCore.instance.amContext?.rootNode()
             }
-            //列表节点
+            //List node
             val listViewNode = AMNodeUtils.getNodeByClassName(rootNode, ListView::class.java.name)
                 ?: throw AMTaskException.business("列表为空")
 
-            //获取listViewItem集合
+            //Get listViewItem collection
             val itemList = AMNodeUtils.getAllNodeById(
                 listViewNode,
                 IAMWidgetWX.messageListItem().resourceId
             )
 
-            ///是否要滑动到最顶部
+            ///Whether to swipe to the top
             var isNoCanSlide = false
             if (data?.extra is Boolean) {
                 isNoCanSlide = data.extra as Boolean
             }
             if (!isNoCanSlide) {
-                //点击最上面回到底部
+                //Tap the top entry to return to bottom
                 AMEventUtils.reProcessUntilOk(
                     helper,
                     3,
@@ -80,17 +80,17 @@ internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
 
 
             for (tvNodeInfo in itemList) {
-                //1.判断节点是否为空
+                //1. Check whether the node is null
                 if (tvNodeInfo == null) continue
                 val nameInfo = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetWX.contactNickName().resourceId
                 )
-                //2.判断用户昵称是否为空 (name可能会重复,先忽略)
+                //2. Check whether the user nickname is empty; name may repeat, ignore for now
                 val name = nameInfo?.text.toString()
                 if (TextUtils.isEmpty(name)) continue
 
-                //3.过滤非红点的节点
+                //3.Filter nodes without red dots
                 val numRedInfo = AMNodeUtils.getFirstNodeById(
                     tvNodeInfo,
                     IAMWidgetWX.messageNumRedItem().resourceId
@@ -98,17 +98,17 @@ internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
                 if (numRedInfo == null) {
                     continue
                 }
-                //4.过滤已经添加的节点
+                //4.Filter already-added nodes
                 if (alreadyAddFriends.contains(name)) {
                     continue
                 }
-                //添加到总数组
+                //Add to the main array
                 alreadyAddFriends.add(name)
-                //添加到临时数组
+                //Add to the temporary array
                 helper.tempNodeList.add(tvNodeInfo)
 
             }
-            //当临时列表不为空时，执行第4步
+            //Execute step 4 when the temporary list is not empty
             if (helper.tempNodeList.isNotEmpty()) {
                 helper.executorService.execute {
                     if (helper.isOngoing()) {
@@ -117,7 +117,7 @@ internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
                 }
                 return condition
             }
-            //滑动
+            //Swipe
             if (listViewNode.performAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD)) {
                 AMEventUtils.sleep(AMActionDelay.MIDDLE)
                 continue
@@ -127,7 +127,7 @@ internal class AMWxAutoReplyStep3(index: Int, helper: AMWxAutoReplyHelper) :
             }
         }
 
-        ///回到第2步继续
+        ///Return to step 2 and continue
         helper.executorService.execute {
             if (helper.isOngoing()) {
                 helper.secondStep()?.onExecute()

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep4.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第4步：分发子任务
+ * Step 4:Dispatch subtasks
  */
 internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
@@ -23,7 +23,7 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
     override val isDispatcher: Boolean
         get() = true
 
-    //记录循环过滤索引
+    //Record loop filter index
     private var tempIndex = 0
 
     init {
@@ -45,7 +45,7 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
             if (i >= tempIndex) {
                 val nodeInfo = helper.tempNodeList[i]
                 AMLog.onEDebugLog("当前子步骤${subStepIndex}")
-                //第5步 - 点击进入
+                //Step 5 - Tap to enter
                 if (subStepIndex == 5) {
                     val nameInfo = AMNodeUtils.getFirstNodeById(
                         nodeInfo,
@@ -64,7 +64,7 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
 
                 }
 
-                //第6步 - 传参数给AI，获取评论
+                //Step 6 - Pass parameters to AI and get comment
                 if (subStepIndex in 5..6 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -77,7 +77,7 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
                         }.second
                 }
 
-                //第7步 - 自动回复
+                //Step 7 - Auto-reply
                 if (subStepIndex in 5..7 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -90,7 +90,7 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
                         }.second
                 }
 
-                //回到首页
+                //Return to home page
                 AMWxPageEvent.back2WeChatHomePage(object : IAMPageEvent.IAMTaskCallBack {
                     override fun action(): Boolean {
                         return helper.isTaskPauseOrStop() || !helper.isOngoing()
@@ -99,13 +99,13 @@ internal class AMWxAutoReplyStep4(index: Int, helper: AMWxAutoReplyHelper) :
 
 
                 subStepIndex = 5
-                //增加过滤索引
+                //Increment filter index
                 tempIndex++
             }
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         helper.executorService.execute {
-            //回到第3步
+            //Return to step 3
             tempIndex = 0
             AMLog.onEDebugLog("回到第3步")
             helper.thirdStep()?.onExecute(data=AMDataContainer().withExtra(true))

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep5.kt
@@ -10,7 +10,7 @@ import com.coremate.opengui.automation.base.utils.Something
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第5步：获取昵称并点击进入会话
+ * Step 5:Get nickname and tap into conversation
  */
 internal class AMWxAutoReplyStep5(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep6.kt
@@ -17,7 +17,7 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第6步：传参数给AI，获取评论
+ * Step 6:Pass parameters to AI and get comment
  */
 internal class AMWxAutoReplyStep6(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
@@ -33,7 +33,7 @@ internal class AMWxAutoReplyStep6(index: Int, helper: AMWxAutoReplyHelper) :
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //获取最后一条信息
+        //Get the last message
         var recyclerViewNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,
@@ -60,7 +60,7 @@ internal class AMWxAutoReplyStep6(index: Int, helper: AMWxAutoReplyHelper) :
             condition.isCanNext = false
             return condition
         }
-        //获取最后一个节点
+        //Get the last node
         val nodeList = mutableListOf<AccessibilityNodeInfo?>()
         for (i in 0..<(recyclerViewNode?.childCount ?: 0)) {
             val node = recyclerViewNode?.getChild(i)

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/steps/wx/steps/AMWxAutoReplyStep7.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.common.check.steps.wx.AMWxAutoReplyHelper
 
 /**
- * 第7步：自动回复
+ * Step 7:Auto-reply
  */
 internal class AMWxAutoReplyStep7(index: Int, helper: AMWxAutoReplyHelper) :
     AMBaseStep<AMWxAutoReplyHelper>(index, helper) {
@@ -31,7 +31,7 @@ internal class AMWxAutoReplyStep7(index: Int, helper: AMWxAutoReplyHelper) :
         }
 
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //输入框节点
+        //Input field node
         var editNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/test/AMCommonAutoReplyTestActivity.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/common/check/test/AMCommonAutoReplyTestActivity.kt
@@ -24,11 +24,11 @@ class AMCommonAutoReplyTestActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // 初始化 binding
+        // Initialize binding
         binding = ActivityAmcommonAutoTestReplyBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // 设置默认值
+        // Set default values
         val now = Calendar.getInstance()
         val later = Calendar.getInstance().apply {
             add(Calendar.MINUTE, 15)
@@ -70,7 +70,7 @@ class AMCommonAutoReplyTestActivity : AppCompatActivity() {
         DatePickerDialog(
             this,
             { _, year, month, dayOfMonth ->
-                // 日期选完后再弹出时间选择器
+                // Show the time picker after date selection
                 calendar.set(Calendar.YEAR, year)
                 calendar.set(Calendar.MONTH, month)
                 calendar.set(Calendar.DAY_OF_MONTH, dayOfMonth)
@@ -82,7 +82,7 @@ class AMCommonAutoReplyTestActivity : AppCompatActivity() {
                         calendar.set(Calendar.MINUTE, minute)
                         calendar.set(Calendar.SECOND, 0)
 
-                        // 格式化时间
+                        // Format time
                         val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
                         val formatted = sdf.format(calendar.time)
                         targetView.text = formatted

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/bean/AMTkPublishParam.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/bean/AMTkPublishParam.kt
@@ -1,19 +1,19 @@
 package com.coremate.opengui.automation.biz.tasks.tk.bean
 
 data class AMTkPublishParam(
-    //视频主题
+    //Video topic
     var videoText: String? = null,
-    //前几个视频
+    //First N videos
     var videoCount: Int? = null,
-    //视频长度
+    //Video length
     var videoLength: Int? = null,
-    //是否使用业务信息
+    //Whether to use business info
     var isUseUserBg: Boolean? = null,
-    //你所属的行业
+    //Your industry
     var industry: String? = null,
-    //您销售的产品
+    //The product you sell
     var productCategory: String? = null,
-    //您销售的产品特别
+    //Special qualities of the product you sell
     var productFeatures: String? = null,
-    //您的目标客户
+    //Your target customer
     var targetCustomerGroup: String? = null, )

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/AMTkPublishVideoMixTask.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/AMTkPublishVideoMixTask.kt
@@ -12,11 +12,11 @@ internal class AMTkPublishVideoMixTask(amContext: AMContext) :
     AMBaseTask<AMTkPublishVideoMixHelper>(amContext) {
 
     override fun initTaskAndData(dataContainer: AMDataContainer?) {
-        //弹出悬浮窗
+        //Show floating window
         amContext.componentManager?.onExecute(AMCompModel(compCls = EnterFloat::class))
-        //设置数据
+        //Set data
         helper.param = dataContainer?.bean as AMTkPublishParam
-        //注册
+        //Register
         helper.registerSteps(
             AMTkPublishVideoMixStep1::class,
             AMTkPublishVideoMixStep2::class,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep1.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.event.lv.AMLVPageEvent
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第1步：跳转到剪映首页
+ * Step 1:Navigate to Jianying home page
  */
 internal class AMTkPublishVideoMixStep1(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -33,7 +33,7 @@ internal class AMTkPublishVideoMixStep1(index: Int, helper: AMTkPublishVideoMixH
                 return helper.isTaskPauseOrStop()
             }
         }, helper)
-        //判断是否在剪映首页
+        //Check Whether on Jianying home page
         if (!AMLVPageEvent.isInHomePage(helper)) {
             throw AMTaskException.business("不在剪映首页")
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep10.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep10.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第10步：抖音操作下一步
+ * Step 10:Douyin next-step operation
  */
 internal class AMTkPublishVideoMixStep10(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -46,7 +46,7 @@ internal class AMTkPublishVideoMixStep10(index: Int, helper: AMTkPublishVideoMix
 //                }
 //            }).dealWith { isSuc, intercept ->
 //            if (!isSuc) {
-//                throw AMTaskException.business("点击下一步失败")
+// throw AM Task Exception.business("Tap next Failure")
 //            }
 //        }
 //

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep11.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep11.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第11步：最终发布(废弃)
+ * Step 11: final publish (deprecated)
  */
 internal class AMTkPublishVideoMixStep11(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep2.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第2步：点击营销视频
+ * Step 2:Tap Marketing video
  */
 internal class AMTkPublishVideoMixStep2(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -49,7 +49,7 @@ internal class AMTkPublishVideoMixStep2(index: Int, helper: AMTkPublishVideoMixH
             //...
         }
         if (gridViewNode == null) {
-            ///兼容首次布局
+            ///Handle first-run layout
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,
@@ -74,7 +74,7 @@ internal class AMTkPublishVideoMixStep2(index: Int, helper: AMTkPublishVideoMixH
             if (gridViewNode == null) {
                 throw AMTaskException.business("未找到营销视频所在列表")
             }
-            //点击进入营销成片
+            //Tap into marketing finished video
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,
@@ -104,7 +104,7 @@ internal class AMTkPublishVideoMixStep2(index: Int, helper: AMTkPublishVideoMixH
                 }
             }
         } else {
-            //点击进入营销视频
+            //Tap to enter Marketing video
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep3.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第3步：判断权限和其他确定按钮
+ * Step 3:Check permissions and other confirm buttons
  */
 internal class AMTkPublishVideoMixStep3(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -52,7 +52,7 @@ internal class AMTkPublishVideoMixStep3(index: Int, helper: AMTkPublishVideoMixH
         }
 
         if (isHasDialog) {
-            //点击AI弹窗确定
+            //Tap confirm in AI dialog
             AMEventUtils.reProcessUntilOk(
                 helper,
                 2,
@@ -80,7 +80,7 @@ internal class AMTkPublishVideoMixStep3(index: Int, helper: AMTkPublishVideoMixH
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
         }
 
-        //点击去试试
+        //Tap try it
         AMEventUtils.reProcessUntilOk(
             helper,
             2,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep4.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第4步：选择素材
+ * Step 4:Select material
  */
 internal class AMTkPublishVideoMixStep4(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -27,7 +27,7 @@ internal class AMTkPublishVideoMixStep4(index: Int, helper: AMTkPublishVideoMixH
         }
         SelectToSpeakService.service?.changeAccessibilityFlags(false)
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //获取素材列表
+        //Get Material list
         var listNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep5.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第5步：点击下一步
+ * Step 5:Tap next
  */
 internal class AMTkPublishVideoMixStep5(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep6.kt
@@ -17,7 +17,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第6步：填写信息，点击合成
+ * Step 6:Fill information and tap compose
  */
 internal class AMTkPublishVideoMixStep6(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {
@@ -62,7 +62,7 @@ internal class AMTkPublishVideoMixStep6(index: Int, helper: AMTkPublishVideoMixH
 
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         var editNode: AccessibilityNodeInfo? = null
-        //长按
+        //Long press
         AMEventUtils.reProcessUntilOk(
             helper,
             10,
@@ -91,7 +91,7 @@ internal class AMTkPublishVideoMixStep6(index: Int, helper: AMTkPublishVideoMixH
 
         AMEventUtils.sleep(AMActionDelay.LONG)
         AMEventUtils.sleep(AMActionDelay.MINI)
-        //粘贴
+        //Paste
         AMEventUtils.reProcessUntilOk(
             helper,
             3,
@@ -118,7 +118,7 @@ internal class AMTkPublishVideoMixStep6(index: Int, helper: AMTkPublishVideoMixH
             }).dealWith { isSuc, intercept ->
         }
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //点击键盘消失
+        //Tap to hide keyboard
         AMEventUtils.reProcessUntilOk(
             helper,
             3,
@@ -146,7 +146,7 @@ internal class AMTkPublishVideoMixStep6(index: Int, helper: AMTkPublishVideoMixH
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击合成
+        //Tap compose
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep7.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第7步：等待合成
+ * Step 7:Wait for composition
  */
 internal class AMTkPublishVideoMixStep7(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep8.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep8.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第8步：点击导出
+ * Step 8:Tap export
  */
 internal class AMTkPublishVideoMixStep8(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep9.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/mixvideo/steps/AMTkPublishVideoMixStep9.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.mixvideo.AMTkPublishVideoMixHelper
 
 /**
- * 第9步：等待导出，判断是否直接跳转到抖音
+ * Step 9:Wait for export and check whether it jumps directly to Douyin
  */
 internal class AMTkPublishVideoMixStep9(index: Int, helper: AMTkPublishVideoMixHelper) :
     AMBaseStep<AMTkPublishVideoMixHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/AMTkPublishVideoTask.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/AMTkPublishVideoTask.kt
@@ -12,11 +12,11 @@ internal class AMTkPublishVideoTask(amContext: AMContext) :
     AMBaseTask<AMTkPublishVideoHelper>(amContext) {
 
     override fun initTaskAndData(dataContainer: AMDataContainer?) {
-        //弹出悬浮窗
+        //Show floating window
         amContext.componentManager?.onExecute(AMCompModel(compCls = EnterFloat::class))
-        //设置数据
+        //Set data
         helper.param = dataContainer?.bean as AMTkPublishParam
-        //注册
+        //Register
         helper.registerSteps(
             AMTkPublishVideoStep1::class,
             AMTkPublishVideoStep2::class,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep1.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.event.lv.AMLVPageEvent
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第1步：跳转到剪映首页
+ * Step 1:Navigate to Jianying home page
  */
 internal class AMTkPublishVideoStep1(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -30,7 +30,7 @@ internal class AMTkPublishVideoStep1(index: Int, helper: AMTkPublishVideoHelper)
 
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
         SelectToSpeakService.service?.changeAccessibilityFlags(false)
-        //判断返回首页
+        //Check returned home page
         AMLVPageEvent.backHomePage(object : IAMPageEvent.IAMTaskCallBack {
             override fun action(): Boolean {
                 return helper.isTaskPauseOrStop()
@@ -38,13 +38,13 @@ internal class AMTkPublishVideoStep1(index: Int, helper: AMTkPublishVideoHelper)
         }, helper)
         AMEventUtils.sleep(AMActionDelay.LONG)
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
-        //再次判断
+        //Check again
         AMLVPageEvent.backHomePage(object : IAMPageEvent.IAMTaskCallBack {
             override fun action(): Boolean {
                 return helper.isTaskPauseOrStop()
             }
         }, helper)
-        //判断是否在剪映首页
+        //Check Whether on Jianying home page
         if (!AMLVPageEvent.isInHomePage(helper)) {
             throw AMTaskException.business("不在剪映首页")
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep10.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep10.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第10步：点击生成视频
+ * Step 10:Tap to generate video
  */
 internal class AMTkPublishVideoStep10(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -26,7 +26,7 @@ internal class AMTkPublishVideoStep10(index: Int, helper: AMTkPublishVideoHelper
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
         AMEventUtils.sleep(AMActionDelay.LONG)
 
-        //点击生成视频
+        //Tap to generate video
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep11.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep11.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第11步：判断是否能生成视频的条件
+ * Step 11:Check conditions for video generation
  */
 internal class AMTkPublishVideoStep11(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -27,7 +27,7 @@ internal class AMTkPublishVideoStep11(index: Int, helper: AMTkPublishVideoHelper
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
 
-        //判断是否开通了SVIP
+        //Check whether SVIP is enabled
         AMEventUtils.reProcessUntilOk(
             helper,
             3,
@@ -55,7 +55,7 @@ internal class AMTkPublishVideoStep11(index: Int, helper: AMTkPublishVideoHelper
 
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击确定使用
+        //Tap confirm use
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep12.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep12.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第12步：视频生成中监听
+ * Step 12:Observe video generation in progress
  */
 internal class AMTkPublishVideoStep12(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep13.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep13.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第13步：点击导出
+ * Step 13:Tap export
  */
 internal class AMTkPublishVideoStep13(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep14.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep14.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第14步：监听是否导出完成
+ * Step 14:Observe whether export is complete
  */
 internal class AMTkPublishVideoStep14(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep15.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep15.kt
@@ -12,7 +12,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第15步：判断在分享之前，有没有其他弹窗
+ * Step 15:Check for other dialogs before sharing
  */
 internal class AMTkPublishVideoStep15(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -24,7 +24,7 @@ internal class AMTkPublishVideoStep15(index: Int, helper: AMTkPublishVideoHelper
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击弹窗关闭
+        //Tap dialog close
         AMEventUtils.reProcessUntilOk(
             helper,
             2,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep16.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep16.kt
@@ -14,7 +14,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第16步：点击分享到抖音
+ * Step 16:Tap share to Douyin
  */
 internal class AMTkPublishVideoStep16(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -26,7 +26,7 @@ internal class AMTkPublishVideoStep16(index: Int, helper: AMTkPublishVideoHelper
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
 
-        //点击分享到抖音
+        //Tap share to Douyin
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep17.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep17.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第17步：抖音操作下一步
+ * Step 17:Douyin next-step operation
  */
 internal class AMTkPublishVideoStep17(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -45,7 +45,7 @@ internal class AMTkPublishVideoStep17(index: Int, helper: AMTkPublishVideoHelper
 //                }
 //            }).dealWith { isSuc, intercept ->
 //            if (!isSuc) {
-//                throw AMTaskException.business("点击下一步失败")
+// throw AM Task Exception.business("Tap next Failure")
 //            }
 //        }
 //        helper.executorService.execute {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep18.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep18.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.tk.IAMWidgetTK
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第18步：最终发布(废弃)
+ * Step 18: final publish (deprecated)
  */
 internal class AMTkPublishVideoStep18(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep2.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第2步：点击AI故事
+ * Step 2:TapAI story
  */
 internal class AMTkPublishVideoStep2(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -49,7 +49,7 @@ internal class AMTkPublishVideoStep2(index: Int, helper: AMTkPublishVideoHelper)
             //...
         }
         if (gridViewNode == null) {
-            ///兼容首次布局
+            ///Handle first-run layout
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,
@@ -74,7 +74,7 @@ internal class AMTkPublishVideoStep2(index: Int, helper: AMTkPublishVideoHelper)
             if (gridViewNode == null) {
                 throw AMTaskException.business("未找到营销视频所在列表")
             }
-            //点击进入营销成片
+            //Tap into marketing finished video
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,
@@ -104,7 +104,7 @@ internal class AMTkPublishVideoStep2(index: Int, helper: AMTkPublishVideoHelper)
                 }
             }
         } else {
-            //点击进入营销视频
+            //Tap to enter Marketing video
             AMEventUtils.reProcessUntilOk(
                 helper,
                 10,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep3.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第3步：判断权限和其他确定按钮
+ * Step 3:Check permissions and other confirm buttons
  */
 internal class AMTkPublishVideoStep3(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -25,7 +25,7 @@ internal class AMTkPublishVideoStep3(index: Int, helper: AMTkPublishVideoHelper)
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击我知道了
+        //Tap Got it
         AMEventUtils.reProcessUntilOk(
             helper,
             2,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep4.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第4步：点击AI生成
+ * Step 4:Tap AI generation
  */
 internal class AMTkPublishVideoStep4(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -25,7 +25,7 @@ internal class AMTkPublishVideoStep4(index: Int, helper: AMTkPublishVideoHelper)
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击AI生成按钮
+        //Tap AI generation button
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep5.kt
@@ -17,7 +17,7 @@ import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第5步：输入要AI生成的内容
+ * Step 5:Enter the content for AI generation
  */
 internal class AMTkPublishVideoStep5(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -29,7 +29,7 @@ internal class AMTkPublishVideoStep5(index: Int, helper: AMTkPublishVideoHelper)
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
 
-        //输入框节点
+        //Input field node
         var editNode: AccessibilityNodeInfo? = null
         AMEventUtils.reProcessUntilOk(
             helper,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep6.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- *  第6步：点击生成AI文案
+ * Step 6:Tap to generate AI copy
  */
 internal class AMTkPublishVideoStep6(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -25,7 +25,7 @@ internal class AMTkPublishVideoStep6(index: Int, helper: AMTkPublishVideoHelper)
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
 
-        //点击生成AI文案
+        //Tap to generate AI copy
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep7.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第7步：判断是否生成完成
+ * Step 7:Check whether generation is complete
  */
 internal class AMTkPublishVideoStep7(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep8.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep8.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第8步：点击插入
+ * Step 8:Tap Insert
  */
 internal class AMTkPublishVideoStep8(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -25,7 +25,7 @@ internal class AMTkPublishVideoStep8(index: Int, helper: AMTkPublishVideoHelper)
         }
         AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-        //点击插入AI文案
+        //Tap to insert AI copy
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep9.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/tk/video/steps/AMTkPublishVideoStep9.kt
@@ -16,7 +16,7 @@ import com.coremate.opengui.automation.biz.common.node.lv.IAMWidgetLV
 import com.coremate.opengui.automation.biz.tasks.tk.video.AMTkPublishVideoHelper
 
 /**
- * 第9步：点击应用
+ * Step 9:Tap Apply
  */
 internal class AMTkPublishVideoStep9(index: Int, helper: AMTkPublishVideoHelper) :
     AMBaseStep<AMTkPublishVideoHelper>(index, helper) {
@@ -50,11 +50,11 @@ internal class AMTkPublishVideoStep9(index: Int, helper: AMTkPublishVideoHelper)
 //            }).dealWith { isSuc, intercept ->
 //            if (isSuc) {
 //                val bText = editNode?.text.toString()
-//                AMEventUtils.setTextToEditText(editNode, bText+"\n视频时长限制在:${helper.param?.videoLength}秒以内")
+// AMEventUtils.setTextToEditText(editNode, bText + "\nVideo duration limit: ${helper.param?.videoLength} seconds")
 //            }
 //        }
 //        AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
-        //点击应用
+        //Tap Apply
         AMEventUtils.reProcessUntilOk(
             helper,
             3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/AMWxLikeCommentHelper.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/AMWxLikeCommentHelper.kt
@@ -8,19 +8,19 @@ internal class AMWxLikeCommentHelper : AMBaseStepHelper() {
 
     var param: AMWxLikeCommentParam? = null
 
-    //成功添加的数量
+    //Number added successfully
     var sucCount = 0
 
-    //临时节点
+    //temporary Node
     val tempNodeList = mutableListOf<AccessibilityNodeInfo>()
 
-    //列表
+    //List
     var listNode: AccessibilityNodeInfo? = null
 
-    //临时评论内容
+    //Temporary comment content
     var tempCommentText = "赞"
 
-    //是否完成
+    //Whether complete
     var isFinish = false
 
     override fun onObserveTaskResume() {

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/AMWxLikeCommentTask.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/AMWxLikeCommentTask.kt
@@ -12,11 +12,11 @@ internal class AMWxLikeCommentTask(amContext: AMContext) :
     AMBaseTask<AMWxLikeCommentHelper>(amContext) {
 
     override fun initTaskAndData(dataContainer: AMDataContainer?) {
-        //弹出悬浮窗
+        //Show floating window
         amContext.componentManager?.onExecute(AMCompModel(compCls = EnterFloat::class))
-        //设置数据
+        //Set data
         helper.param = dataContainer?.bean as AMWxLikeCommentParam
-        //注册
+        //Register
         helper.registerSteps(
             AMWxLikeCommentStep1::class,
             AMWxLikeCommentStep2::class,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/bean/AMWxLikeCommentItemNode.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/bean/AMWxLikeCommentItemNode.kt
@@ -6,14 +6,14 @@ import com.coremate.opengui.automation.base.utils.AMNodeUtils
 import com.coremate.opengui.automation.biz.common.event.wx.AMWxPageEvent
 import com.coremate.opengui.automation.biz.common.node.wx.IAMWidgetWX
 
-//节点模型过滤
+//Node model filter
 data class AMWxLikeCommentItemNode(
-    var userName: String = "",                //用户名
-    var momentText: String = "",        //文字
-    var imageCount: Int = 0             //图片数量
+    var userName: String = "",                // Username.
+    var momentText: String = "",        // Text.
+    var imageCount: Int = 0             // Image count.
 ) {
     companion object {
-        //通过节点转换为节点模型
+        //Convert node to node model
         fun transFormNode(contentNode: AccessibilityNodeInfo?): AMWxLikeCommentItemNode? {
             if (contentNode == null) return null
 
@@ -21,23 +21,23 @@ data class AMWxLikeCommentItemNode(
             if (contentNode.className != LinearLayout::class.java.name) {
                 return data
             }
-            //用户名
+            // Username.
             val nameNode =
                 AMNodeUtils.getFirstNodeById(contentNode, IAMWidgetWX.fcListUserName().resourceId)
             data.userName = nameNode?.text?.toString() ?: ""
 
 
-            //获取内部的LinearLayout集合
+            // Get inner LinearLayout collection.
             val llList = AMNodeUtils.getAllNodeByClassName(
                 contentNode,
                 LinearLayout::class.java.name
             )
-            //获取文字的LinearLayout
+            // Get text LinearLayout.
             var centerTopTextNode: AccessibilityNodeInfo? = null
 
             if (llList.isNotEmpty()) {
                 val list = llList.filter {
-                    //过滤带图片的文字链接 和 音乐
+                    //Filter text links with images and music
                     AMNodeUtils.getFirstNodeByDesc(
                         it,
                         false,
@@ -51,7 +51,7 @@ data class AMWxLikeCommentItemNode(
                 if (list.isNotEmpty()) {
                     centerTopTextNode = list.first()
                 }
-                //获取朋友圈文字
+                //Get Moments Text
                 if (centerTopTextNode != null) {
                     data.momentText =
                         AMWxPageEvent.getMomentTextFromMomentByLike(centerTopTextNode)
@@ -61,7 +61,7 @@ data class AMWxLikeCommentItemNode(
             } else {
                 data.momentText = ""
             }
-            //获取图片数量
+            //Get image count
             val imageNodes =
                 AMNodeUtils.getFirstNodeById(contentNode, IAMWidgetWX.fcListImages().resourceId)
             data.imageCount = imageNodes?.childCount ?: 0

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/bean/AMWxLikeCommentParam.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/bean/AMWxLikeCommentParam.kt
@@ -4,16 +4,16 @@ import com.coremate.opengui.common_jvm.enums.CommentLength
 
 
 enum class AMWxLikeCommentEventType {
-    LIKE, //点赞
-    COMMENT, //评论
-    LIKE_AND_COMMENT //点赞和评论
+    LIKE, // Like.
+    COMMENT, // Comment.
+    LIKE_AND_COMMENT // Like and comment.
 }
 
 data class AMWxLikeCommentParam(
-    //事件类型
+    //Event type
     var eventType: AMWxLikeCommentEventType = AMWxLikeCommentEventType.LIKE,
-    //评论文字选择 (eventType = COMMENT 或者 LIKE_AND_COMMENT，使用)
+    // Comment text selection, used when eventType is COMMENT or LIKE_AND_COMMENT.
     var wordNum: CommentLength = CommentLength.SHORT,
-    //触达次数
+    //Reach count
     var count: Int = 1
 )

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep1.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep1.kt
@@ -11,7 +11,7 @@ import com.coremate.opengui.automation.biz.common.event.wx.AMWxPageEvent
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentHelper
 
 /**
- * 第1步：跳转到微信朋友圈
+ * Step 1:Navigate to We Chat Moments
  */
 internal class AMWxLikeCommentStep1(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -35,7 +35,7 @@ internal class AMWxLikeCommentStep1(index: Int, helper: AMWxLikeCommentHelper) :
                 throw AMTaskException.business("进入朋友圈失败")
             }
         }
-        //判断是否在朋友圈
+        //Check whether on Moments
         AMWxPageEvent.comeToFriendMoments(helper, condition).let {
             if (it.isIntercept) return it
         }

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep10.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep10.kt
@@ -19,7 +19,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第10步：评论3
+ * Step 10:comment 3
  */
 internal class AMWxLikeCommentStep10(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -34,7 +34,7 @@ internal class AMWxLikeCommentStep10(index: Int, helper: AMWxLikeCommentHelper) 
         if (helper.param?.eventType == AMWxLikeCommentEventType.COMMENT || helper.param?.eventType == AMWxLikeCommentEventType.LIKE_AND_COMMENT) {
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
             val nodeInfo = data?.bean as AccessibilityNodeInfo
-            //点击评论按钮
+            //Tap comment button
             AMEventUtils.reProcessUntilOk(
                 helper,
                 3,
@@ -45,7 +45,7 @@ internal class AMWxLikeCommentStep10(index: Int, helper: AMWxLikeCommentHelper) 
                     }
 
                     override fun work(timeIndex: Int): Boolean {
-                        //获取更多按钮
+                        //Get the more button
                         val btnNode = AMNodeUtils.getFirstNodeById(
                             nodeInfo,
                             IAMWidgetWX.fcMoreBtn().resourceId
@@ -59,7 +59,7 @@ internal class AMWxLikeCommentStep10(index: Int, helper: AMWxLikeCommentHelper) 
             }
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
             AMEventUtils.sleep(AMActionDelay.MINI)
-            //点击输入评论内容
+            //Tap and enter comment content
             AMEventUtils.reProcessUntilOk(
                 helper,
                 3,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep11.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep11.kt
@@ -14,7 +14,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第11步：评论4，滑动当前朋友圈置顶
+ * Step 11:comment 4, swipe current Moment to top
  */
 internal class AMWxLikeCommentStep11(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -30,7 +30,7 @@ internal class AMWxLikeCommentStep11(index: Int, helper: AMWxLikeCommentHelper) 
         }
 
         if (helper.param?.eventType == AMWxLikeCommentEventType.COMMENT || helper.param?.eventType == AMWxLikeCommentEventType.LIKE_AND_COMMENT) {
-            //判断更多按钮是否在屏幕内
+            //Check whether the more button is on screen
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
             val nodeInfo = data?.bean as AccessibilityNodeInfo
             AMEventUtils.reProcessUntilOk(
@@ -43,7 +43,7 @@ internal class AMWxLikeCommentStep11(index: Int, helper: AMWxLikeCommentHelper) 
                     }
 
                     override fun work(timeIndex: Int): Boolean {
-                        //获取更多按钮并点击
+                        //Get the more button and tap it
                         val btnNode = AMNodeUtils.getFirstNodeById(
                             nodeInfo,
                             IAMWidgetWX.fcMoreBtn().resourceId

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep2.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep2.kt
@@ -15,7 +15,7 @@ import com.coremate.opengui.automation.biz.common.event.wx.AMWxPageEvent
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentHelper
 
 /**
- * 第2步: 判断是否在朋友圈并滑动到顶部
+ * Step 2: Check whether on Moments and swipe to top
  */
 internal class AMWxLikeCommentStep2(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -27,11 +27,11 @@ internal class AMWxLikeCommentStep2(index: Int, helper: AMWxLikeCommentHelper) :
         }
 
         AMEventUtils.sleep(AMActionDelay.MIDDLE_LONG)
-        //判断否在朋友圈
+        //Check whether not on Moments
         AMWxPageEvent.comeToFriendMoments(helper, condition, isException = true).let {
             if (it.isIntercept) return it
         }
-        //滑动到顶部
+        //Swipe to top
         val listNode = AMNodeUtils.getNodeByClassName(
             AMCore.instance.amContext?.rootNode(),
             RecyclerView::class.java.name

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep3.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep3.kt
@@ -16,12 +16,12 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentItemNode
 
 /**
- * 第3步：获取列表节点集合
+ * Step 3: Get list node collection
  */
 internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
 
-    //已经加入的节点
+    //Already-added nodes
     private var alreadyAddNode = mutableListOf<AMWxLikeCommentItemNode>()
 
     override fun onExecute(data: AMDataContainer?, isResume: Boolean): AMStepCondition {
@@ -31,10 +31,10 @@ internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
         }
 
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //清空临时列表
+        //Clear temporary list
         helper.tempNodeList.clear()
         if (helper.isFinish) {
-            //完成
+            //Complete
             helper.amContext.processListener?.onProcessTaskFinish(
                 true,
                 System.currentTimeMillis() - helper.startTime,
@@ -47,13 +47,13 @@ internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
                 AMLog.onEDebugLog("任务停止在第${index}步1 - 步骤内")
                 return condition.interceptted()
             }
-            //获取当前页面所有朋友圈
+            //Get all Moments on the current page
             val rootNode = AMCore.instance.amContext?.rootNode()
-            //页面listview
+            //Page List View
             val listNode = AMNodeUtils.getNodeByClassName(rootNode, RecyclerView::class.java.name)
             helper.listNode = listNode
             val momentList = AMWxPageEvent.getMoments2()
-            //判断朋友圈是否为空
+            //Check Momentswhetheris empty
             if (momentList.isEmpty()) {
                 throw AMTaskException.business("朋友圈是空的")
             }
@@ -65,19 +65,19 @@ internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
                     IAMWidgetWX.fcMoreBtn().resourceId
                 ) ?: continue
                 val nodeData = AMWxLikeCommentItemNode.transFormNode(itemNode)
-                //过滤已经添加的节点
+                //Filter already-added nodes
                 if (nodeData != null && alreadyAddNode.contains(nodeData)) {
                     continue
                 }
-                //记录
+                //Record
                 if (nodeData != null) {
                     helper.tempNodeList.add(itemNode)
                     alreadyAddNode.add(nodeData)
-                    //TODO:只记录一条
+                    //TODO: record only one item
                     break
                 }
             }
-            //当临时列表不为空时，执行第4步
+            //Execute step 4 when the temporary list is not empty
             if (helper.tempNodeList.isNotEmpty()) {
                 AMLog.onEDebugLog("本次有${helper.tempNodeList.size}条")
                 helper.executorService.execute {
@@ -86,7 +86,7 @@ internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
                 return condition
             }
             var isSwipe = false
-            //判断加载中
+            //Check loading state
             while (true) {
                 if (AMNodeUtils.getFirstNodeByText(listNode, true, "正在加载") == null) break
                 if (!isSwipe) {
@@ -98,19 +98,19 @@ internal class AMWxLikeCommentStep3(index: Int, helper: AMWxLikeCommentHelper) :
                     return condition.interceptted()
                 }
             }
-            //判断结束
+            //Check end state
             if (helper.sucCount >= (helper.param?.count ?: 0)) {
                 AMLog.onEDebugLog("缓存完毕，结束循环")
                 break
             }
 
 //            if (listNode?.performAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD) == false) {
-//                AMLog.onEDebugLog("滑动完毕，结束循环")
+// AMLog.onEDebugLog("Swipe complete, end loop")
 //                break
 //            }
             AMEventUtils.sleep(AMActionDelay.LONG)
         }
-        //完成
+        //Complete
         helper.amContext.processListener?.onProcessTaskFinish(
             true,
             System.currentTimeMillis() - helper.startTime,

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep4.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep4.kt
@@ -7,7 +7,7 @@ import com.coremate.opengui.automation.base.utils.AMLog
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentHelper
 
 /**
- * 第4步：任务分发
+ * Step 4:Task dispatch
  */
 internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -15,7 +15,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
     override val isDispatcher: Boolean
         get() = true
 
-    //记录循环过滤索引
+    //Record loop filter index
     private var tempIndex = 0
 
     init {
@@ -33,7 +33,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
             if (i >= tempIndex) {
                 val nodeInfo = helper.tempNodeList[i]
                 AMLog.onEDebugLog("当前子步骤${subStepIndex}")
-                //第5步 - 检测
+                //Step 5 - Check
                 if (subStepIndex == 5) {
                     isCanNext =
                         onExecuteSubStep(
@@ -47,7 +47,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
 
                 }
 
-                //第6步 - 点赞1
+                //Step 6 - like 1
                 if (subStepIndex in 5..6 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -60,7 +60,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                         }.second
                 }
 
-                //第7步 - 点赞2
+                //Step 7 - like 2
                 if (subStepIndex in 5..7 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -73,7 +73,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                         }.second
                 }
 
-                //第8步 - 评论1
+                //Step 8 - comment 1
                 if (subStepIndex in 5..8 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -85,7 +85,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                             }
                         }.second
                 }
-                //第9步 - 评论2
+                //Step 9 - comment 2
                 if (subStepIndex in 5..9 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -97,7 +97,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                             }
                         }.second
                 }
-                //第10步 - 评论3
+                //Step 10 - comment 3
                 if (subStepIndex in 5..10 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -109,7 +109,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                             }
                         }.second
                 }
-                //第11步 - 评论4
+                //Step 11 - comment 4
                 if (subStepIndex in 5..11 && isCanNext) {
                     isCanNext =
                         onExecuteSubStep(
@@ -121,7 +121,7 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                             }
                         }.second
                 }
-                //TODO:暂时，在这里进行成功数量+1
+                //TODO: temporarily increment success count here
                 helper.sucCount += 1
 
                 if (helper.sucCount >= (helper.param?.count ?: 0)) {
@@ -129,12 +129,12 @@ internal class AMWxLikeCommentStep4(index: Int, helper: AMWxLikeCommentHelper) :
                     break
                 }
                 subStepIndex = 5
-                //增加过滤索引
+                //Increment filter index
                 tempIndex++
             }
         }
 
-        //回到第3步
+        //Return to step 3
         helper.executorService.execute {
             tempIndex = 0
             AMLog.onEDebugLog("回到第3步")

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep5.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep5.kt
@@ -16,7 +16,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第5步：检测更多按钮位置
+ * Step 5:Check more button position
  */
 internal class AMWxLikeCommentStep5(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -27,7 +27,7 @@ internal class AMWxLikeCommentStep5(index: Int, helper: AMWxLikeCommentHelper) :
             return condition
         }
         AMEventUtils.sleep(AMActionDelay.SHORT)
-        //判断更多按钮是否在屏幕内
+        //Check whether the more button is on screen
         val nodeInfo = data?.bean as AccessibilityNodeInfo
         AMEventUtils.reProcessUntilOk(
             helper,
@@ -39,7 +39,7 @@ internal class AMWxLikeCommentStep5(index: Int, helper: AMWxLikeCommentHelper) :
                 }
 
                 override fun work(timeIndex: Int): Boolean {
-                    //获取更多按钮并点击
+                    //Get the more button and tap it
                     val btnNode = AMNodeUtils.getFirstNodeById(
                         nodeInfo,
                         IAMWidgetWX.fcMoreBtn().resourceId

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep6.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep6.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第6步：点赞1
+ * Step 6:like 1
  */
 internal class AMWxLikeCommentStep6(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -24,7 +24,7 @@ internal class AMWxLikeCommentStep6(index: Int, helper: AMWxLikeCommentHelper) :
             return condition
         }
 
-        //判断更多按钮是否在屏幕内
+        //Check whether the more button is on screen
         if (helper.param?.eventType == AMWxLikeCommentEventType.LIKE || helper.param?.eventType == AMWxLikeCommentEventType.LIKE_AND_COMMENT) {
             AMEventUtils.sleep(AMActionDelay.SHORT)
             val nodeInfo = data?.bean as AccessibilityNodeInfo
@@ -38,7 +38,7 @@ internal class AMWxLikeCommentStep6(index: Int, helper: AMWxLikeCommentHelper) :
                     }
 
                     override fun work(timeIndex: Int): Boolean {
-                        //获取更多按钮并点击
+                        //Get the more button and tap it
                         val btnNode = AMNodeUtils.getFirstNodeById(
                             nodeInfo,
                             IAMWidgetWX.fcMoreBtn().resourceId

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep7.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep7.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第7步：点赞2
+ * Step 7:like 2
  */
 internal class AMWxLikeCommentStep7(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -41,12 +41,12 @@ internal class AMWxLikeCommentStep7(index: Int, helper: AMWxLikeCommentHelper) :
                     }
 
                     override fun work(timeIndex: Int): Boolean {
-                        //获取更多按钮
+                        //Get the more button
                         val btnNode = AMNodeUtils.getFirstNodeById(
                             nodeInfo,
                             IAMWidgetWX.fcMoreBtn().resourceId
                         ) ?: return false
-                        //点赞
+                        //Like
                         return AMEventUtils.doClickDownByX(btnNode, helper, x = -250f)
                     }
                 }).dealWith { isSuc, intercept ->

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep8.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep8.kt
@@ -10,7 +10,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第8步：评论1 - 截图上传
+ * Step 8: comment 1 - upload screenshot
  */
 internal class AMWxLikeCommentStep8(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -23,7 +23,7 @@ internal class AMWxLikeCommentStep8(index: Int, helper: AMWxLikeCommentHelper) :
         if (helper.param?.eventType == AMWxLikeCommentEventType.COMMENT || helper.param?.eventType == AMWxLikeCommentEventType.LIKE_AND_COMMENT) {
             AMEventUtils.sleep(AMActionDelay.MIDDLE)
 
-//            helper.tempCommentText = "赞"
+// helper.tempCommentText = "Like"
             var isCallBack = false
             AMLog.onEDebugLog("开始请求AI")
 //            AMServiceManager.instance.cozeAIManager?.testScenario_WeChatMomentsComment(

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep9.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/steps/AMWxLikeCommentStep9.kt
@@ -13,7 +13,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentH
 import com.coremate.opengui.automation.biz.tasks.wx.likecomment.bean.AMWxLikeCommentEventType
 
 /**
- * 第9步：评论2 - 点击更多
+ * Step 9:comment 2 - tap more
  */
 internal class AMWxLikeCommentStep9(index: Int, helper: AMWxLikeCommentHelper) :
     AMBaseStep<AMWxLikeCommentHelper>(index, helper) {
@@ -37,7 +37,7 @@ internal class AMWxLikeCommentStep9(index: Int, helper: AMWxLikeCommentHelper) :
                     }
 
                     override fun work(timeIndex: Int): Boolean {
-                        //获取更多按钮并点击
+                        //Get the more button and tap it
                         val btnNode = AMNodeUtils.getFirstNodeById(
                             nodeInfo,
                             IAMWidgetWX.fcMoreBtn().resourceId

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/test/AMWxLikeCommentTestActivity.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/tasks/wx/likecomment/test/AMWxLikeCommentTestActivity.kt
@@ -25,11 +25,11 @@ class AMWxLikeCommentTestActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // 初始化 binding
+        // Initialize binding
         binding = ActivityAmwxLikeCommentTestBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // 设置系统边距
+        // Set system insets
         ViewCompat.setOnApplyWindowInsetsListener(binding.main) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(
@@ -43,7 +43,7 @@ class AMWxLikeCommentTestActivity : AppCompatActivity() {
 
         binding.seekReachCount.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
-                // 避免显示0，最少1次
+                // Avoid displaying 0; minimum is 1
                 val count = if (progress < 1) 1 else progress
                 binding.tvReachCurrent.text = "$count"
             }
@@ -53,7 +53,7 @@ class AMWxLikeCommentTestActivity : AppCompatActivity() {
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
         })
 
-        // 示例：获取输入框内容并处理点击事件
+        // Example: read input content and handle click event
         binding.btnStart.setOnClickListener {
 
             val doLike = binding.switchLike.isChecked

--- a/client/automation/src/main/java/com/coremate/opengui/automation/biz/type/AMTaskBizType.kt
+++ b/client/automation/src/main/java/com/coremate/opengui/automation/biz/type/AMTaskBizType.kt
@@ -8,7 +8,7 @@ import com.coremate.opengui.automation.biz.tasks.wx.likecomment.AMWxLikeCommentT
 import kotlin.reflect.KClass
 
 /**
- * 任务类型
+ * Task type
  * */
 enum class AMTaskBizType(
     val type: String,
@@ -17,7 +17,7 @@ enum class AMTaskBizType(
 ) {
 
     /** common */
-    //自动回复（wx、tk、red）
+    //Auto-reply(wx. tk. red)
     COMMON_AUTO_REPLY(
         "common_auto_reply",
         mutableListOf(
@@ -31,7 +31,7 @@ enum class AMTaskBizType(
     ),
 
     /** wx */
-    //微信评论点赞
+    //We Chat comment and like
     WX_LIKE_COMMENT(
         "wx_like_comment",
         mutableListOf(AMTargetApp.WX, AMTargetApp.SYS_PERMISSION, AMTargetApp.OPLUS_PERMISSION),
@@ -39,7 +39,7 @@ enum class AMTaskBizType(
     ),
 
     /** tk */
-    //抖音发布视频(合成)
+    //Douyin video publishing (composition)
     TK_PUBLISH_VIDEO_MIX(
         "tk_publish_video_mix",
         mutableListOf(
@@ -51,7 +51,7 @@ enum class AMTaskBizType(
         AMTkPublishVideoMixTask::class
     ),
 
-    //抖音发布视频(通过AI)
+    //Douyin video publishing (AI-assisted)
     TK_PUBLISH_VIDEO_AI(
         "tk_publish_video_ai",
         mutableListOf(

--- a/client/automation/src/main/java/com/google/android/accessibility/selecttospeak/SelectToSpeakService.kt
+++ b/client/automation/src/main/java/com/google/android/accessibility/selecttospeak/SelectToSpeakService.kt
@@ -9,33 +9,33 @@ import com.coremate.opengui.automation.base.utils.AMUtils
 import kotlin.reflect.KProperty
 
 /**
- * 辅助服务
+ * Accessibility service
  * */
 class SelectToSpeakService : AccessibilityService() {
 
     companion object {
-        //无障碍服务
+        //Accessibility service
         var service: SelectToSpeakService? = null
     }
 
     private var serviceInfoConfig by AccessibilityConfig()
 
     /**
-     * 绑定service
+ * Bind service
      * */
     override fun onServiceConnected() {
         super.onServiceConnected()
         service = this
         AMLog.onEDebugLog("服务开启")
-        //设置配置信息
+        //Set configuration
         serviceInfoConfig = serviceInfo
         serviceInfo = serviceInfoConfig
-        //跳转回app
+        //Return to the app
 //        AMUtils.jumpToPageInApp(this, AMCore.activityByOp)
     }
 
     /**
-     * 更改是否获取真实布局或者简略布局
+ * Toggle real layout versus simplified layout capture
      * */
     fun changeAccessibilityFlags(isReal: Boolean) {
         serviceInfoConfig = serviceInfo
@@ -55,15 +55,15 @@ class SelectToSpeakService : AccessibilityService() {
     }
 
     /**
-     * 获取到指定的监听事件
+ * Received the specified observed event
      * */
     override fun onAccessibilityEvent(event: AccessibilityEvent) {
-        //辅助功能的事件类型
+        //Accessibility event type
         AMCore.instance.onAccessibilityEvent(event)
     }
 
     /**
-     * 服务被中断
+ * Service interrupted
      * */
     override fun onInterrupt() {
         //....
@@ -71,7 +71,7 @@ class SelectToSpeakService : AccessibilityService() {
     }
 
     /**
-     * service销毁
+ * Service destroyed
      * */
     override fun onDestroy() {
         super.onDestroy()
@@ -81,7 +81,7 @@ class SelectToSpeakService : AccessibilityService() {
 }
 
 /**
- * 配置信息
+ * Configuration
  * */
 class AccessibilityConfig {
     companion object {

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/AopWrappers.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/AopWrappers.kt
@@ -2,7 +2,7 @@ package com.coremate.opengui.aop
 
 import com.coremate.opengui.aop.utils.ConsoleLogger
 import kotlin.system.measureTimeMillis
-import com.coremate.opengui.common_jvm.utils.Logger // 导入 Logger 接口
+import com.coremate.opengui.common_jvm.utils.Logger // Import Logger interface.
 
 public val runtimeLogger: Logger = ConsoleLogger()
 object InMemoryCache {
@@ -25,7 +25,7 @@ object InMemoryCache {
 }
 
 /**
- * 日志包装器：记录代码块执行耗时。
+ * Logging wrapper: records block execution time.
  */
 inline fun <T> logExecutionTime(block: () -> T): T {
     val result: T
@@ -38,19 +38,19 @@ inline fun <T> logExecutionTime(block: () -> T): T {
 }
 
 /**
- * 埋点包装器：发送一个分析事件。
+ * Tracking wrapper: sends an analytics event.
  */
 inline fun <T> trackEvent(eventName: String, block: () -> T): T {
-    // 在这里调用您的分析/埋点SDK
+    // Call the analytics/tracking SDK here
     runtimeLogger.debug("Analytics", "Tracking event: '$eventName'")
     return block()
 }
 
 /**
- * 缓存包装器：执行代码块，如果结果已在缓存中且未过期，则直接返回缓存结果。
- * @param key 缓存的唯一键。
- * @param ttlMillis 缓存的有效时间（毫秒）。
- * @param block 用于获取新数据的代码块。
+ * Cache wrapper: execute the block and return the cached result when present and not expired.
+ * @param key unique cache key.
+ * @param ttl Millis cache duration in milliseconds.
+ * @param block code block used to fetch fresh data.
  */
 suspend fun <T> cacheResult(key: String, ttlMillis: Long, block: suspend () -> T): T {
     val cachedResult: T? = InMemoryCache.get(key)

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/CacheResult.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/CacheResult.kt
@@ -3,10 +3,10 @@ package com.coremate.opengui.aop.annotations
 import kotlin.time.DurationUnit
 
 /**
- * 标记一个方法，表示其结果可以被缓存。
- * @param key 缓存的唯一键。如果为空，将自动生成。
- * @param ttl (Time to Live) 缓存的有效时间。
- * @param unit 缓存有效时间的单位。
+ * Marks a method whose result can be cached.
+ * @param key unique cache key. Generated automatically when empty.
+ * @param ttl cache time to live.
+ * @param unit cache duration unit.
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.SOURCE)

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/LogExecutionTime.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/LogExecutionTime.kt
@@ -1,7 +1,7 @@
 package com.coremate.opengui.aop.annotations
 
 /**
- * 标记一个方法或代码块，表示需要记录其执行耗时。
+ * Marks a method or code block whose execution time should be recorded.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/TrackEvent.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/annotations/TrackEvent.kt
@@ -1,8 +1,8 @@
 package com.coremate.opengui.aop.annotations
 
 /**
- * 标记一个方法或代码块，表示其需要被追踪（埋点）。
- * @param eventName 事件的唯一名称。
+ * Marks a method or code block that should be tracked for analytics.
+ * @param event Name unique event name.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/processor/AopProcessor.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/processor/AopProcessor.kt
@@ -2,7 +2,7 @@ package com.coremate.opengui.aop.processor
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver // 确保导入的是 KSP 的 Resolver
+import com.google.devtools.ksp.processing.Resolver // Ensure this is the KSP Resolver.
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
@@ -13,24 +13,24 @@ class AopProcessor(
     private val logger: KSPLogger
 ) : SymbolProcessor {
 
-    override fun process(resolver: Resolver): List<KSAnnotated> { // 这里的 Resolver 类型现在是 KSP 的 Resolver
+    override fun process(resolver: Resolver): List<KSAnnotated> { // This Resolver type is now the KSP Resolver.
         logger.info("AOP Processor: Running...")
 
-        // 示例：查找所有使用了 @TrackEvent 注解的符号
-        // getSymbolsWithAnnotation 方法是 com.google.devtools.ksp.processing.Resolver 的成员
-        val symbols = resolver.getSymbolsWithAnnotation(TrackEvent::class.qualifiedName!!) // 使用 qualifiedName
+        // Example: find all symbols annotated with @Track Event
+        // get Symbols With Annotation is a member of com.google.devtools.ksp.processing.Resolver
+        val symbols = resolver.getSymbolsWithAnnotation(TrackEvent::class.qualifiedName!!) // Use qualifiedName.
 
         symbols.forEach { symbol ->
-            if (symbol is KSDeclaration) { // 进行类型检查和向下转型
+            if (symbol is KSDeclaration) { // Type-check and downcast.
                 logger.info("Found @TrackEvent on: ${symbol.simpleName.asString()}")
             } else {
-                // 如果 symbol 不是一个声明，你可能需要根据实际情况处理
-                // 例如，@TrackEvent 可能被应用在类型参数或其他非声明的符号上
+                // If the symbol is not a declaration, handle it as needed
+                // For example, @Track Event may be applied to type parameters or other non-declaration symbols
                 logger.warn("Found @TrackEvent on a non-declaration symbol: ${symbol.location}")
             }
         }
 
-        // 返回一个空列表，表示我们不推迟任何符号的处理。
+        // Return an empty list to indicate that no symbols are deferred.
         return emptyList()
     }
 }

--- a/client/core_aop/src/main/java/com/coremate/opengui/aop/utils/ConsoleLogger.kt
+++ b/client/core_aop/src/main/java/com/coremate/opengui/aop/utils/ConsoleLogger.kt
@@ -12,7 +12,7 @@ class ConsoleLogger : Logger {
     }
 
     override fun warn(tag: String, message: String) {
-        System.err.println("WARN/$tag: $message") // 警告和错误通常打印到标准错误流
+        System.err.println("WARN/$tag: $message") // Warnings and errors usually go to stderr.
     }
 
     override fun error(tag: String, message: String, throwable: Throwable?) {

--- a/client/core_common/src/main/java/com/coremate/opengui/common/interfaces/MockScreenshotProvider.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/interfaces/MockScreenshotProvider.kt
@@ -13,15 +13,15 @@ import java.io.InputStream
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
- * Mock 实现的 ScreenshotProvider，用于从 assets 加载预设图片进行测试。
+ * Mock Screenshot Provider implementation that loads preset images from assets for tests.
  */
 class MockScreenshotProvider(
     private val context: Context,
-    private val imageAssetPaths: List<String> // 传入 assets 目录下的图片路径列表
+    private val imageAssetPaths: List<String> // Image paths under the assets directory.
 ) : ScreenshotProvider {
 
     private val runtimeLogger: Logger = AndroidLogger()
-    private val imageIndex = AtomicInteger(0) // 用于轮询图片列表
+    private val imageIndex = AtomicInteger(0) // Used to cycle through the image list.
 
     override suspend fun capture(): Bitmap? = withContext(Dispatchers.IO) {
         if (imageAssetPaths.isEmpty()) {
@@ -29,7 +29,7 @@ class MockScreenshotProvider(
             return@withContext null
         }
 
-        // 轮询图片列表
+        // Cycle through the image list
         val currentIndex = imageIndex.getAndIncrement() % imageAssetPaths.size
         val imagePath = imageAssetPaths[currentIndex]
 

--- a/client/core_common/src/main/java/com/coremate/opengui/common/interfaces/ScreenshotProvider.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/interfaces/ScreenshotProvider.kt
@@ -2,17 +2,17 @@
 
 package com.coremate.opengui.common.interfaces
 
-import android.graphics.Bitmap // 接口中使用 Bitmap，所以此接口必须在 Android 模块
+import android.graphics.Bitmap // Bitmap keeps this interface in an Android module.
 
 /**
- * 提供截图功能的抽象接口。
- * 旨在打破模块间的直接依赖，实现依赖倒置。
+ * Abstraction for screenshot capture.
+ * Breaks direct module dependencies through dependency inversion.
  */
 interface ScreenshotProvider {
     /**
-     * 捕获当前屏幕截图。
-     * 这是一个 suspend 函数，必须在协程作用域内调用。
-     * @return 屏幕截图的 Bitmap 对象，如果捕获失败则返回 null。
+ * Capture the current screen.
+ * This is a suspend function and must be called from a coroutine scope.
+ * @return screenshot Bitmap, or null when capture fails.
      */
     suspend fun capture(): Bitmap?
 }

--- a/client/core_common/src/main/java/com/coremate/opengui/common/launcher/AppLauncher.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/launcher/AppLauncher.kt
@@ -54,30 +54,30 @@ object AppLauncher {
      * This is an heuristic and might not be perfectly accurate for all apps.
      *
      * @param context The context to use.
-     * @param appName The human-readable name of the app (e.g., "抖音", "微信").
+ * @param app Name The human-readable name of the app (e.g., "Douyin", "We Chat").
      * @return The package name if found, or null otherwise.
      */
     fun getPackageNameFromAppName(context: Context, appName: String): String? {
         val packageManager = context.packageManager
         val installedApplications = packageManager.getInstalledApplications(PackageManager.GET_META_DATA)
 
-        // 优先使用预定义的常量映射
+        // Prefer predefined constant mappings
         val predefinedPackageName = when (appName) {
             "抖音" -> Constants.AppPackageNames.DOUYIN
             "微信" -> Constants.AppPackageNames.WECHAT
             "QQ" -> Constants.AppPackageNames.QQ
-            // ... 添加更多预定义映射
+            //... Add more predefined mappings
             else -> null
         }
         if (predefinedPackageName != null) {
             return predefinedPackageName
         }
 
-        // 尝试遍历已安装应用，通过应用标签进行模糊匹配 (性能较低，精确度不高)
+        // Try scanning installed apps and fuzzy-match by app label; slower and less accurate
         for (app in installedApplications) {
             val appLabel = packageManager.getApplicationLabel(app).toString()
-            if (appLabel.equals(appName, ignoreCase = true) || // 精确匹配
-                appLabel.contains(appName, ignoreCase = true)) { // 包含匹配
+            if (appLabel.equals(appName, ignoreCase = true) || // Exact match.
+                appLabel.contains(appName, ignoreCase = true)) { // Contains match.
                 return app.packageName
             }
         }

--- a/client/core_common/src/main/java/com/coremate/opengui/common/log/LogManager.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/log/LogManager.kt
@@ -22,9 +22,9 @@ object LogManager {
             SQLiteManager.Companion.getInstance(context)
                 .insertLog(System.currentTimeMillis(), message)
             Log.d(tag, message)
-            // 检查是否需要创建新的日志文件（基于日期）
+            // Check whether a new log file should be created based on date
             checkAndCreateLogFile()
-            // 如果当前日志文件为空，则返回
+            // Return if the current log file is empty
             if (currentLogFile == null) {
                 Log.e(TAG, "Failed to create log file")
                 return
@@ -36,14 +36,14 @@ object LogManager {
 
     private fun checkAndCreateLogFile() {
         val today = SimpleDateFormat("MM_dd", Locale.getDefault()).format(Date())
-        // 如果日期发生变化或文件不存在，创建新的日志文件
+        // Create a new log file when the date changes or the file is missing
         if (currentDate != today || currentLogFile == null || !currentLogFile!!.exists()) {
             currentDate = today
             val fileName = "$LOG_FILE_PREFIX$today$LOG_FILE_SUFFIX"
-            // 获取 Download 目录
+            // Get the Download directory
             val downloadDir =
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
-            // 确保目录存在
+            // Ensure the directory exists
             if (!downloadDir.exists()) {
                 downloadDir.mkdirs()
             }
@@ -51,9 +51,9 @@ object LogManager {
         }
     }
 
-    // 提供一个方法来设置 Context（在实际使用中需要调用此方法）
+    // Provide a method for setting Context; callers must invoke it in real use
     fun init() {
-        // 初始化时立即检查并创建日志文件
+        // Check and create the log file immediately during initialization
         checkAndCreateLogFile()
     }
 }

--- a/client/core_common/src/main/java/com/coremate/opengui/common/sqlite/SQLiteManager.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/sqlite/SQLiteManager.kt
@@ -75,36 +75,36 @@ class SQLiteManager private constructor(context: Context) :
     fun queryLogs(content: String): List<String> {
         val resultList = mutableListOf<String>()
 
-        // 1. 定位：找到符合条件的记录，并获取其时间戳（或ID）作为锚点
-        // 我们直接查最后 2 条记录
+        // 1. Locate matching records and use their timestamp (or ID) as the anchor
+        // Query the last 2 records directly
         val anchorTime = readableDatabase.query(
             TABLE_LOG,
-            arrayOf(COLUMN_TIME), // 只取时间戳列
+            arrayOf(COLUMN_TIME), // Read only the timestamp column.
             "$COLUMN_DATA = ?",
             arrayOf(content),
             null, null,
-            "$COLUMN_TIME DESC", // 按时间倒序
-            "2"                  // 取最近的两条
+            "$COLUMN_TIME DESC", // Sort by time descending.
+            "2"                  // Read the two most recent rows.
         ).use { cursor ->
             if (cursor.moveToLast()) {
-                // 如果只有 1 条，moveToLast 会停在第 1 条
-                // 如果有 2 条，moveToLast 会停在第 2 条（即倒数第二条）
+                // With only 1 record, move ToLast stops at the first record
+                // With 2 records, move ToLast stops at the second record, i.e. the penultimate one
                 cursor.getLong(0)
             } else {
-                -1L // 一条都没有
+                -1L // No rows.
             }
         }
 
         if (anchorTime == -1L) return emptyList()
 
-        // 2. 切片：查询在该时间点之后（不包含该点本身）的所有数据
+        // 2. Slice: query all data after that timestamp, excluding the anchor itself
         readableDatabase.query(
             TABLE_LOG,
             arrayOf(COLUMN_DATA),
             "$COLUMN_TIME >= ?",
             arrayOf(anchorTime.toString()),
             null, null,
-            "$COLUMN_TIME ASC" // 结果按时间正序排列
+            "$COLUMN_TIME ASC" // Return results in ascending time order.
         ).use { cursor ->
             val dataIndex = cursor.getColumnIndexOrThrow(COLUMN_DATA)
             while (cursor.moveToNext()) {
@@ -115,7 +115,7 @@ class SQLiteManager private constructor(context: Context) :
         return resultList
     }
 
-    /** 返回日志总条数 */
+ /** Return total log row count */
     fun getLogCount(): Long {
         val cursor = readableDatabase.rawQuery(
             "SELECT COUNT(*) FROM $TABLE_LOG",
@@ -126,7 +126,7 @@ class SQLiteManager private constructor(context: Context) :
         }
     }
 
-    /** 返回日志时间范围 [最早时间戳, 最晚时间戳]，无数据时返回 null to null */
+ /** Return log time range [earliest timestamp, latest timestamp], or null to null when there is no data */
     fun getLogTimeRange(): Pair<Long?, Long?> {
         val cursor = readableDatabase.rawQuery(
             "SELECT MIN(CAST($COLUMN_TIME AS INTEGER)), MAX(CAST($COLUMN_TIME AS INTEGER)) FROM $TABLE_LOG",
@@ -144,12 +144,12 @@ class SQLiteManager private constructor(context: Context) :
     @RequiresApi(Build.VERSION_CODES.O)
     fun timestampMsToBeijing(timestampStr: String): String {
         val timestamp = timestampStr.toLong()
-        // 区分秒和毫秒
+        // Distinguish seconds from milliseconds
         val instant = if (timestamp > 1_000_000_000_000L) {
-            // 毫秒时间戳（13位）
+            // Millisecond timestamp (13 digits)
             Instant.ofEpochMilli(timestamp)
         } else {
-            // 秒时间戳（10位）
+            // Second timestamp (10 digits)
             Instant.ofEpochSecond(timestamp)
         }
         val beijingTime = instant.atZone(ZoneId.of("Asia/Shanghai"))

--- a/client/core_common/src/main/java/com/coremate/opengui/common/utils/AutomationConfigManager.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/utils/AutomationConfigManager.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import com.google.gson.Gson
 
 /**
- * 自动化脚本配置管理类。
- * 用于本地缓存和读取自动化脚本的参数配置。
+ * Automation script configuration manager.
+ * Caches and reads automation script parameter configuration locally.
  */
 object AutomationConfigManager {
 
@@ -13,10 +13,10 @@ object AutomationConfigManager {
     private val gson = Gson()
 
     /**
-     * 保存指定脚本的配置。
-     * @param context 应用上下文。
-     * @param scriptName 脚本的唯一名称（作为 SharedPreferences 的 key）。
-     * @param config 脚本的配置对象。
+ * Save configuration for the specified script.
+ * @param context application context.
+ * @param script Name unique script name used as the Shared Preferences key.
+ * @param config script configuration object.
      */
     fun <T> saveConfig(context: Context, scriptName: String, config: T) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -26,11 +26,11 @@ object AutomationConfigManager {
     }
 
     /**
-     * 读取指定脚本的配置。
-     * @param context 应用上下文。
-     * @param scriptName 脚本的唯一名称（作为 SharedPreferences 的 key）。
-     * @param classOfT 配置对象的 Class 类型。
-     * @return 对应的配置对象，如果不存在则返回 null。
+ * Read configuration for the specified script.
+ * @param context application context.
+ * @param script Name unique script name used as the Shared Preferences key.
+ * @param class OfT Class type for the configuration object.
+ * @return matching configuration object, or null when absent.
      */
     fun <T> loadConfig(context: Context, scriptName: String, classOfT: Class<T>): T? {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -48,14 +48,14 @@ object AutomationConfigManager {
         }
     }
 
-    // 辅助函数：清除某个脚本的配置
+    // Helper: clear configuration for one script
     fun clearConfig(context: Context, scriptName: String) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit().remove(scriptName).apply()
         AndroidLogger().info("AutomationConfigManager", "Cleared config for $scriptName")
     }
 
-    // 辅助函数：清除所有配置 (慎用)
+    // Helper: clear all configuration; use with care
     fun clearAllConfigs(context: Context) {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         prefs.edit().clear().apply()

--- a/client/core_common/src/main/java/com/coremate/opengui/common/utils/CommonUtils.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/utils/CommonUtils.kt
@@ -3,17 +3,17 @@ package com.coremate.opengui.common.utils
 import android.content.Context
 
 /**
- * 通用工具类
- * 提供常用的工具方法
+ * Common utility class
+ * Provides common utility methods
  */
 object CommonUtils {
 
     /**
-     * 将 dp 转换为 px
+ * Convert dp to px
      *
-     * @param context 应用上下文
-     * @param dpValue dp 值
-     * @return 转换后的 px 值
+ * @param context application context
+ * @param dp Value dp value
+ * @return converted px value
      */
     fun dpToPx(context: Context, dpValue: Float): Int {
         val displayMetrics = context.resources.displayMetrics
@@ -21,33 +21,33 @@ object CommonUtils {
     }
 
     /**
-     * 将 dp 转换为 px (Double 版本)
+ * Convert dp to px (Double version)
      *
-     * @param context 应用上下文
-     * @param dpValue dp 值
-     * @return 转换后的 px 值
+ * @param context application context
+ * @param dp Value dp value
+ * @return converted px value
      */
     fun dpToPx(context: Context, dpValue: Double): Int {
         return dpToPx(context, dpValue.toFloat())
     }
 
     /**
-     * 将 dp 转换为 px (Int 版本)
+ * Convert dp to px (Int version)
      *
-     * @param context 应用上下文
-     * @param dpValue dp 值
-     * @return 转换后的 px 值
+ * @param context application context
+ * @param dp Value dp value
+ * @return converted px value
      */
     fun dpToPx(context: Context, dpValue: Int): Int {
         return dpToPx(context, dpValue.toFloat())
     }
 
     /**
-     * 将 px 转换为 dp
+ * Convert px to dp
      *
-     * @param context 应用上下文
-     * @param pxValue px 值
-     * @return 转换后的 dp 值
+ * @param context application context
+ * @param px Value px value
+ * @return converted dp value
      */
     fun pxToDp(context: Context, pxValue: Float): Int {
         val displayMetrics = context.resources.displayMetrics
@@ -55,10 +55,10 @@ object CommonUtils {
     }
 
     /**
-     * 获取屏幕宽度 (px)
+ * Get screen width in px
      *
-     * @param context 应用上下文
-     * @return 屏幕宽度
+ * @param context application context
+ * @return screen width
      */
     fun getScreenWidth(context: Context): Int {
         val displayMetrics = context.resources.displayMetrics
@@ -66,10 +66,10 @@ object CommonUtils {
     }
 
     /**
-     * 获取屏幕高度 (px)
+ * Get screen height in px
      *
-     * @param context 应用上下文
-     * @return 屏幕高度
+ * @param context application context
+ * @return screen height
      */
     fun getScreenHeight(context: Context): Int {
         val displayMetrics = context.resources.displayMetrics
@@ -77,10 +77,10 @@ object CommonUtils {
     }
 
     /**
-     * 获取屏幕密度
+ * Get screen density
      *
-     * @param context 应用上下文
-     * @return 屏幕密度
+ * @param context application context
+ * @return screen density
      */
     fun getScreenDensity(context: Context): Float {
         return context.resources.displayMetrics.density
@@ -88,40 +88,40 @@ object CommonUtils {
 }
 
 /**
- * Float 扩展函数：将 dp 转换为 px
+ * Float Extension functions:Convert dp to px
  *
- * @param context 应用上下文
- * @return 转换后的 px 值
+ * @param context application context
+ * @return converted px value
  */
 fun Float.dpToPx(context: Context): Int {
     return CommonUtils.dpToPx(context, this)
 }
 
 /**
- * Int 扩展函数：将 dp 转换为 px
+ * Int Extension functions:Convert dp to px
  *
- * @param context 应用上下文
- * @return 转换后的 px 值
+ * @param context application context
+ * @return converted px value
  */
 fun Int.dpToPx(context: Context): Int {
     return CommonUtils.dpToPx(context, this)
 }
 
 /**
- * Double 扩展函数：将 dp 转换为 px
+ * Double Extension functions:Convert dp to px
  *
- * @param context 应用上下文
- * @return 转换后的 px 值
+ * @param context application context
+ * @return converted px value
  */
 fun Double.dpToPx(context: Context): Int {
     return CommonUtils.dpToPx(context, this)
 }
 
 /**
- * Float 扩展函数：将 px 转换为 dp
+ * Float Extension functions:Convert px to dp
  *
- * @param context 应用上下文
- * @return 转换后的 dp 值
+ * @param context application context
+ * @return converted dp value
  */
 fun Float.pxToDp(context: Context): Int {
     return CommonUtils.pxToDp(context, this)

--- a/client/core_common/src/main/java/com/coremate/opengui/common/utils/ImageUtils.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/utils/ImageUtils.kt
@@ -3,11 +3,11 @@
 package com.coremate.opengui.common.utils
 
 import android.graphics.Bitmap
-import android.util.Base64 // android.util.Base64 是 Android 平台特有的
+import android.util.Base64 // android.util.Base64 is Android-specific.
 import java.io.ByteArrayOutputStream
 
 /**
- * 图像处理工具类。
+ * Image processing utilities.
  */
 object ImageUtils {
 

--- a/client/core_common/src/main/java/com/coremate/opengui/common/utils/KeyboardUtil.java
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/utils/KeyboardUtil.java
@@ -6,12 +6,12 @@ import android.widget.EditText;
 
 
 /**
- * 键盘工具
+ * Keyboard utility
  */
 public class KeyboardUtil {
 
     /**
-     * 打开键盘
+ * Open the keyboard
      *
      * @param mEditText
      */
@@ -24,7 +24,7 @@ public class KeyboardUtil {
     }
 
     /**
-     * 关闭软键盘
+ * Close the soft keyboard
      *
      * @param mEditText
      */

--- a/client/core_common/src/main/java/com/coremate/opengui/common/utils/TimeUtils.kt
+++ b/client/core_common/src/main/java/com/coremate/opengui/common/utils/TimeUtils.kt
@@ -58,7 +58,7 @@ object TimeUtils {
     }
 
     /**
-     * 用于执行记录列表：返回北京时间的日期部分 yyyy-MM-dd，与 Web 端一致。
+ * For execution record lists: return the Beijing-date portion as yyyy-MM-dd, aligned with web.
      */
     fun getHistoryDatePart(utcString: String?): String {
         if (utcString.isNullOrBlank()) return ""
@@ -72,7 +72,7 @@ object TimeUtils {
     }
 
     /**
-     * 用于执行记录列表：根据开始/结束时间计算时长，格式与 Web 一致，如 "2m 30s" 或 "45s"。
+ * For execution record lists: compute duration from start/end time in the same format as web, such as "2m 30s" or "45s".
      */
     fun getHistoryDuration(startedAt: String?, finishedAt: String?): String {
         if (startedAt.isNullOrBlank() || finishedAt.isNullOrBlank()) return ""
@@ -89,7 +89,7 @@ object TimeUtils {
         }
     }
 
-    // 扩展函数
+    // Extension functions
     fun String.toTimestamp(): Long = utcToTimestamp(this)
     fun Long.toUtcString(): String? = timestampToUtc(this)
     fun Long.toBeijingUtcString(): String? = timestampToZoneTime(this)

--- a/client/feature_promotor/build.gradle.kts
+++ b/client/feature_promotor/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     implementation("io.noties.markwon:core:4.6.2")
     implementation("com.google.android.material:material:1.12.0")
 
-// Markwon 核心库
+// Markwon core library
     implementation("io.noties.markwon:core:4.6.2"){
         exclude(group = "org.jetbrains", module = "annotations")
         exclude(group = "org.jetbrains", module = "annotations-java5")
@@ -108,16 +108,16 @@ dependencies {
         exclude(group = "org.jetbrains", module = "annotations-java5")
     }
 
-    implementation("io.noties.markwon:ext-latex:4.6.2") // 数学公式支持
-    implementation("io.noties.markwon:ext-tables:4.6.2") // 表格的使用
-    implementation("io.noties.markwon:inline-parser:4.6.2") // 表格的使用
+    implementation("io.noties.markwon:ext-latex:4.6.2") // Math formula support
+    implementation("io.noties.markwon:ext-tables:4.6.2") // Table support
+    implementation("io.noties.markwon:inline-parser:4.6.2") // Table support
     implementation("io.noties.markwon:linkify:4.6.2")
     implementation("io.noties.markwon:recycler-table:4.6.2")
     implementation("io.noties.markwon:image:4.6.2")
     implementation("io.noties.markwon:ext-tasklist:4.6.2")
     implementation("io.noties.markwon:ext-strikethrough:4.6.2")
     api("com.github.lihangleo2:ShadowLayout:3.4.5")
-// 强制使用一个版本的注解库
+// Force a single annotation library version
     implementation("io.noties:prism4j:2.0.0"){
         exclude(group = "org.jetbrains", module = "annotations")
         exclude(group = "org.jetbrains", module = "annotations-java5")
@@ -127,10 +127,10 @@ dependencies {
 
     implementation("com.github.gzu-liyujiang.AndroidPicker:WheelPicker:4.1.14")
 
-    // 基础依赖包，必须要依赖
+    // Base dependency package; required
     implementation("com.geyifeng.immersionbar:immersionbar:3.2.2")
-// kotlin扩展（可选）
+// Kotlin extension (optional)
     implementation("com.geyifeng.immersionbar:immersionbar-ktx:3.2.2")
-// fragment快速实现（可选）已废弃
+// Fragment quick implementation (optional, deprecated)
     implementation("com.geyifeng.immersionbar:immersionbar-components:3.2.2")
 }

--- a/server/apps/backend/src/modules/graph-agent/graph/nodes/plan-supervisor.node.spec.ts
+++ b/server/apps/backend/src/modules/graph-agent/graph/nodes/plan-supervisor.node.spec.ts
@@ -1,10 +1,10 @@
 /**
- * Plan Supervisor 结构化输出集成测试
+ * Plan Supervisor structured-output integration tests
  *
- * 验证 ChatOpenAI + createAgent + providerStrategy 能否拿到 structuredResponse
- * 使用真实模型调用，mock 数据尽量简化
+ * Verify that ChatOpenAI + createAgent + providerStrategy can produce structuredResponse
+ * Use a real model call with simplified mock data
  *
- * 运行：pnpm test -- plan-supervisor.node.spec
+ * Run: pnpm test -- plan-supervisor.node.spec
  */
 
 import { HumanMessage } from "@langchain/core/messages";
@@ -13,7 +13,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { createAgent, providerStrategy } from "langchain";
 import { z } from "zod";
 
-// ====== API 配置（与 plan-supervisor.node.ts 保持一致）======
+// ====== API config (kept aligned with plan-supervisor.node.ts)======
 const API_KEY = process.env.VLM_API_KEY ?? "test-api-key-placeholder";
 const BASE_URL =
 	process.env.VLM_BASE_URL ?? "https://dashscope.aliyuncs.com/compatible-mode/v1";
@@ -34,7 +34,7 @@ const SupervisorOutputSchema = z.object({
 
 type SupervisorOutput = z.infer<typeof SupervisorOutputSchema>;
 
-// ====== Mock 工具 ======
+// ====== Mock tools ======
 const mockWriteTodos = tool(
 	async ({ todos }) => `已创建 ${todos.length} 个待办事项`,
 	{
@@ -73,7 +73,7 @@ const mockLoadSkill = tool(
 	},
 );
 
-describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
+describe("Plan Supervisor - ChatOpenAI structured-output integration tests", () => {
 	let model: ChatOpenAI;
 
 	beforeAll(() => {
@@ -88,7 +88,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		});
 	});
 
-	it("无工具：providerStrategy 直接返回 structuredResponse", async () => {
+	it("No tools: providerStrategy returns structuredResponse directly", async () => {
 		const agent = createAgent({
 			model,
 			tools: [],
@@ -117,7 +117,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		expect(typeof response.total_complete).toBe("boolean");
 	}, 120000);
 
-	it("带工具：模型先调用工具再返回 structuredResponse", async () => {
+	it("With tools: the model calls a tool before returning structuredResponse", async () => {
 		const agent = createAgent({
 			model,
 			tools: [mockWriteTodos, mockReadTodos],
@@ -151,7 +151,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		expect(response.total_complete).toBe(false);
 	}, 120000);
 
-	it("带 load_skill 工具：模拟 supervisor 加载 skill 后返回结构化输出", async () => {
+	it("With load_skill: simulate the supervisor loading a skill before returning structured output", async () => {
 		const agent = createAgent({
 			model,
 			tools: [mockWriteTodos, mockReadTodos, mockLoadSkill],
@@ -194,7 +194,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		expect(response.total_complete).toBe(false);
 	}, 120000);
 
-	it("完成场景：所有任务完成时返回 total_complete=true", async () => {
+	it("Completion path: returns total_complete=true when all tasks are done", async () => {
 		const completedReadTodos = tool(
 			async () =>
 				JSON.stringify({
@@ -244,7 +244,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		expect(response.total_complete).toBe(true);
 	}, 120000);
 
-	it("多轮对话：模拟首次规划 + 执行反馈的连续调用", async () => {
+	it("Multi-turn conversation: simulate initial planning followed by execution feedback", async () => {
 		const todosState: Array<{ content: string; status: string }> = [];
 
 		const statefulWriteTodos = tool(
@@ -289,7 +289,7 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 3. 所有子任务完成后设置 total_complete=true
 使用中文。`;
 
-		// 第一轮：首次规划
+		// Round 1: initial planning
 		const agent1 = createAgent({
 			model,
 			tools: [statefulWriteTodos, statefulReadTodos],
@@ -315,12 +315,12 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		expect(response1.total_complete).toBe(false);
 		expect(response1.current_sub_task.length).toBeGreaterThan(0);
 
-		// 标记第一个任务完成
+		// Mark the first task complete
 		if (todosState.length > 0) {
 			todosState[0].status = "completed";
 		}
 
-		// 第二轮：执行反馈
+		// Round 2: execution feedback
 		const agent2 = createAgent({
 			model,
 			tools: [statefulWriteTodos, statefulReadTodos],
@@ -349,12 +349,12 @@ describe("PlanSupervisor - ChatOpenAI 结构化输出集成测试", () => {
 		);
 
 		expect(response2).toBeDefined();
-		// 第二轮应该要么继续下一个子任务，要么完成
+		// The second round should either continue with the next subtask or finish
 		if (response2.total_complete) {
-			// 如果所有任务都完成了
+			// If all tasks are complete
 			expect(response2.total_complete).toBe(true);
 		} else {
-			// 还有下一个子任务
+			// There is another subtask
 			expect(response2.current_sub_task.length).toBeGreaterThan(0);
 		}
 	}, 240000);

--- a/server/apps/backend/test/ws-integration/helpers/create-test-app.ts
+++ b/server/apps/backend/test/ws-integration/helpers/create-test-app.ts
@@ -1,9 +1,9 @@
 /**
  * create-test-app.ts
  *
- * NestJS TestingModule 工厂，创建一个最小的 WS 测试应用。
- * 使用真实的 ExecutionGateway + ExecutionSocketService + WsAuthMiddleware，
- * 但所有外部依赖（Prisma、Redis、GraphRunner、BullMQ、Auth）均为 mock。
+ * NestJS Testing Module factory for creating a minimal WS test app.
+ * Uses the real ExecutionGateway + ExecutionSocketService + WsAuthMiddleware,
+ * but all external dependencies (Prisma, Redis, GraphRunner, BullMQ, Auth) are mocked.
  */
 import { type INestApplication } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
@@ -31,8 +31,8 @@ import {
 // ============================================================
 // Module-level jest.mock for Better-Auth
 // ============================================================
-// 注意：此文件中的 jest.mock 必须在测试文件的顶部 import 前生效
-// 由于 jest.mock 会被提升 (hoisted)，我们在测试文件顶部处理
+// Note: jest.mock in this file must take effect before imports at the top of the test file
+// Because jest.mock is hoisted, this is handled at the top of the test file
 
 export interface TestApp {
 	app: INestApplication;
@@ -53,7 +53,7 @@ export async function createTestApp(): Promise<TestApp> {
 	const mockGraphRunner = createMockGraphRunner();
 	const mockQueue = createMockQueue();
 
-	// Mock LeaseService — 所有方法默认成功
+	// Mock Lease Service; all methods succeed by default
 	const mockLeaseService = {
 		createLease: jest.fn().mockResolvedValue(true),
 		renewLease: jest.fn().mockResolvedValue(true),
@@ -66,7 +66,7 @@ export async function createTestApp(): Promise<TestApp> {
 		renewLeasesBatch: jest.fn().mockResolvedValue([]),
 	};
 
-	// Mock TaskExecutionService — 核心方法可编程
+	// Mock TaskExecutionService; core methods are programmable
 	const mockTaskExecutionService = {
 		startExecution: jest.fn().mockResolvedValue(undefined),
 		startForkExecution: jest.fn().mockResolvedValue(undefined),
@@ -113,18 +113,18 @@ export async function createTestApp(): Promise<TestApp> {
 
 	const app = moduleFixture.createNestApplication();
 
-	// 获取 Gateway 并手动注入 lazy-resolved 依赖
-	// （在真实应用中这些是通过 ModuleRef 在 onModuleInit 解析的）
+	// Get the Gateway and manually inject lazy-resolved dependencies
+	// (In the real app these are resolved through Module Ref in on Module Init)
 	const gateway = moduleFixture.get(ExecutionGateway);
 	const socketService = moduleFixture.get(ExecutionSocketService);
 
-	// 手动设置 Gateway 的 lazy 依赖（绕过 ModuleRef 动态 import）
+	// Manually set Gateway lazy dependencies, bypassing Module Ref dynamic import
 	(gateway as any).taskExecutionService = mockTaskExecutionService;
 	(gateway as any).graphRunnerService = mockGraphRunner;
 
 	await app.init();
 
-	// 获取 HTTP server 和端口
+	// Get the HTTP server and port
 	const httpServer = app.getHttpServer() as Server;
 	await new Promise<void>((resolve) => {
 		httpServer.listen(0, () => resolve());
@@ -150,7 +150,7 @@ export async function createTestApp(): Promise<TestApp> {
 }
 
 /**
- * 重置所有 mock 状态（在 afterEach 中调用）
+ * Reset all mock state, called from afterEach
  */
 export function resetAllMocks(testApp: TestApp) {
 	testApp.mockPrisma._reset();
@@ -183,6 +183,6 @@ export function resetAllMocks(testApp: TestApp) {
 		async (id: number) => testApp.mockPrisma.getExecution(id) ?? null,
 	);
 
-	// 清理 Gateway 内部状态
+	// Clean up Gateway internal state
 	(testApp.gateway as any).readyReceived?.clear();
 }

--- a/server/apps/backend/test/ws-integration/helpers/deferred.ts
+++ b/server/apps/backend/test/ws-integration/helpers/deferred.ts
@@ -1,8 +1,8 @@
 /**
- * Deferred<T> — Promise 控制工具
+ * Deferred<T> - Promise control helper
  *
- * 允许测试在外部控制 Promise 的 resolve/reject 时机，
- * 用于模拟 GraphRunner 等异步执行的精确时序控制。
+ * Allows tests to control Promise resolve/reject timing externally,
+ * Used to precisely control async execution timing for GraphRunner and similar code.
  */
 export class Deferred<T> {
 	promise: Promise<T>;

--- a/server/apps/backend/test/ws-integration/helpers/mock-auth.ts
+++ b/server/apps/backend/test/ws-integration/helpers/mock-auth.ts
@@ -1,20 +1,20 @@
 /**
  * Mock Better-Auth
  *
- * 替代 src/lib/auth 中的 auth 对象。
- * 通过控制 getSession 返回值来模拟不同认证场景。
+ * Replace the auth object from src/lib/auth.
+ * Simulate authentication scenarios by controlling get Session return values.
  */
 
-/** 当前模拟的 session 返回值 */
+/** Current simulated session return value */
 let currentSession: any = null;
 
-/** 按 token 映射的 session（支持多用户测试） */
+/** Map sessions by token; supports multi-user tests */
 const tokenSessionMap = new Map<string, any>();
 
 export const mockAuth = {
 	api: {
 		getSession: jest.fn(async (opts: { headers: Headers }) => {
-			// 优先按 token 查找
+			// Prefer lookup by token
 			const authHeader = opts.headers.get("Authorization");
 			if (authHeader) {
 				const token = authHeader.replace("Bearer ", "");
@@ -27,21 +27,21 @@ export const mockAuth = {
 };
 
 /**
- * 设置默认 session（所有 token 生效）
+ * Set the default session for all tokens
  */
 export function setMockSession(session: any) {
 	currentSession = session;
 }
 
 /**
- * 为特定 token 设置 session
+ * Set the session for a specific token
  */
 export function setMockSessionForToken(token: string, session: any) {
 	tokenSessionMap.set(token, session);
 }
 
 /**
- * 创建一个标准的用户 session
+ * Create a standard user session
  */
 export function createUserSession(userId: number | string) {
 	return {
@@ -58,7 +58,7 @@ export function createUserSession(userId: number | string) {
 }
 
 /**
- * 重置所有 mock 状态
+ * Reset all mock state
  */
 export function resetMockAuth() {
 	currentSession = null;

--- a/server/apps/backend/test/ws-integration/helpers/mock-bullmq.ts
+++ b/server/apps/backend/test/ws-integration/helpers/mock-bullmq.ts
@@ -1,8 +1,8 @@
 /**
  * Mock BullMQ Queue
  *
- * 模拟 @nestjs/bullmq 注入的 Queue 对象，
- * 记录 add() 调用并提供可编程的 getJob() 返回。
+ * Mock the Queue object injected by @nestjs/bullmq,
+ * Record add() calls and provide programmable get Job() responses.
  */
 export function createMockQueue() {
 	const jobs = new Map<string, any>();

--- a/server/apps/backend/test/ws-integration/helpers/mock-graph-runner.ts
+++ b/server/apps/backend/test/ws-integration/helpers/mock-graph-runner.ts
@@ -1,8 +1,8 @@
 /**
  * Mock GraphRunnerService
  *
- * 使用 Deferred 模式控制异步执行。
- * 暴露 hasExecution / preRegisterExecution / cancelExecution / pauseExecution 等方法。
+ * Use the Deferred pattern to control async execution.
+ * Expose methods such as has Execution, pre Register Execution, cancel Execution, and pause Execution.
  */
 import { Deferred } from "./deferred";
 
@@ -51,7 +51,7 @@ export function createMockGraphRunner() {
 				_skipSummary?: boolean,
 			): Promise<MockCancelExecutionResult> => {
 				registeredExecutions.delete(taskExecutionId);
-				// 自动 resolve 任何悬挂的 execution deferred
+				// Automatically resolve any pending execution deferred
 				const d = executionDeferreds.get(taskExecutionId);
 				if (d && !d.settled) {
 					d.resolve({ success: false, cancelled: true, abortReason: "cancel" });

--- a/server/apps/backend/test/ws-integration/helpers/mock-prisma.ts
+++ b/server/apps/backend/test/ws-integration/helpers/mock-prisma.ts
@@ -1,8 +1,8 @@
 /**
  * Mock PrismaService
  *
- * 内存存储 + CAS 语义，模拟 task_execution 表操作。
- * 支持 findUnique, findFirst, create, update, updateMany（CAS）。
+ * In-memory storage with CAS semantics for task_execution table operations.
+ * Supports find Unique, find First, create, update, and update Many (CAS).
  */
 
 export interface MockExecution {
@@ -86,8 +86,8 @@ export function createMockPrisma() {
 		}),
 
 		/**
-		 * CAS 语义：仅当 WHERE 条件全部匹配时才更新
-		 * 返回 { count: 0 | 1 }
+ * CAS semantics: update only when every WHERE condition matches
+ * Returns { count: 0 | 1 }
 		 */
 		updateMany: jest.fn(async (args: any) => {
 			const where = args.where || {};
@@ -120,7 +120,7 @@ export function createMockPrisma() {
 				tenant_id: 1,
 			})),
 		},
-		// 暴露内部存储用于测试验证
+		// Expose internal storage for test assertions
 		_executions: executions,
 		_reset() {
 			executions.clear();
@@ -133,7 +133,7 @@ export function createMockPrisma() {
 			}
 		},
 		/**
-		 * 便捷方法：插入一条 execution 记录
+ * Convenience method: insert one execution record
 		 */
 		seedExecution(overrides: Partial<MockExecution> & { id: number }): MockExecution {
 			const exec: MockExecution = {

--- a/server/apps/backend/test/ws-integration/helpers/mock-redis.ts
+++ b/server/apps/backend/test/ws-integration/helpers/mock-redis.ts
@@ -1,8 +1,8 @@
 /**
  * Mock RedisService
  *
- * 内存 Map 实现，支持 TTL 模拟。
- * 覆盖 LeaseService 和 TaskExecutionService 中使用的所有 Redis 方法。
+ * In-memory Map implementation with TTL simulation.
+ * Covers all Redis methods used by LeaseService and TaskExecutionService.
  */
 
 interface Entry {

--- a/server/apps/backend/test/ws-integration/helpers/socket-client.ts
+++ b/server/apps/backend/test/ws-integration/helpers/socket-client.ts
@@ -1,22 +1,22 @@
 /**
- * Socket.IO Client 辅助工具
+ * Socket.IO client helpers
  *
- * 提供创建认证 Socket.IO 客户端、等待事件、收集事件等辅助方法。
+ * Provides helpers for creating authenticated Socket.IO clients, waiting for events, and collecting events.
  */
 import { io, type Socket } from "socket.io-client";
 
-/** 跟踪所有创建的客户端以便 afterEach 清理 */
+/** Track all created clients so afterEach can clean them up */
 const activeSockets: Socket[] = [];
 
 export interface ClientOptions {
 	token?: string;
 	executionId?: number;
-	/** 额外传给 socket.io-client 的选项 */
+	/** Extra options passed to socket.io-client */
 	extraAuth?: Record<string, any>;
 }
 
 /**
- * 创建已认证的 Socket.IO 客户端并等待连接成功
+ * Create an authenticated Socket.IO client and wait for connection
  */
 export function createClient(
 	port: number,
@@ -36,7 +36,7 @@ export function createClient(
 }
 
 /**
- * 连接客户端并等待 connect 事件
+ * Connect the client and wait for the connect event
  */
 export function connectClient(socket: Socket, timeout = 5000): Promise<void> {
 	return new Promise((resolve, reject) => {
@@ -59,7 +59,7 @@ export function connectClient(socket: Socket, timeout = 5000): Promise<void> {
 }
 
 /**
- * 等待指定事件，返回事件 payload
+ * Wait for the given event and return its payload
  */
 export function waitForEvent<T = any>(
 	socket: Socket,
@@ -82,7 +82,7 @@ export function waitForEvent<T = any>(
 }
 
 /**
- * 等待 disconnect 事件
+ * Wait for the disconnect event
  */
 export function waitForDisconnect(
 	socket: Socket,
@@ -106,7 +106,7 @@ export function waitForDisconnect(
 }
 
 /**
- * 收集指定事件的所有 payload（持续一段时间）
+ * Collect all payloads for the given event over a short duration
  */
 export function collectEvents<T = any>(
 	socket: Socket,
@@ -130,7 +130,7 @@ export function collectEvents<T = any>(
 }
 
 /**
- * 断开所有活跃的测试客户端
+ * Disconnect all active test clients
  */
 export function disconnectAll(): void {
 	for (const socket of activeSockets) {
@@ -143,7 +143,7 @@ export function disconnectAll(): void {
 }
 
 /**
- * 辅助方法：发送 execution:ready 并等待 execution:started
+ * Helper: send execution:ready and wait for execution:started
  */
 export async function emitReadyAndWaitStarted(
 	socket: Socket,
@@ -156,7 +156,7 @@ export async function emitReadyAndWaitStarted(
 }
 
 /**
- * 小延迟，用于等待异步操作完成
+ * Short delay for async operations to settle
  */
 export function delay(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));

--- a/server/apps/backend/test/ws-integration/ws-integration.e2e-spec.ts
+++ b/server/apps/backend/test/ws-integration/ws-integration.e2e-spec.ts
@@ -1,19 +1,19 @@
 /**
- * WS 通信 + 任务执行 集成测试
+ * WS communication + task execution integration tests
  *
- * 使用真实的 ExecutionGateway / ExecutionSocketService / WsAuthMiddleware，
- * 配合 socket.io-client 模拟 Android 客户端，验证：
- * 1. 核心主链路（execute → ready → streaming → finish）
- * 2. 暂停/恢复
- * 3. 取消任务
- * 4. 连接机制与边界情况
- * 5. 心跳与租约
- * 6. 超时
- * 7. 竞态条件
+ * Uses the real ExecutionGateway / ExecutionSocketService / WsAuthMiddleware,
+ * Uses socket.io-client to simulate an Android client and verify:
+ * 1. core path (execute -> ready -> streaming -> finish)
+ * 2. pause/resume
+ * 3. task cancellation
+ * 4. connection mechanics and edge cases
+ * 5. heartbeats and leases
+ * 6. timeouts
+ * 7. race conditions
  */
 
-// jest.mock 必须在 import 之前（会被 hoisted）
-// ====== ESM-only 依赖 mock（避免 pnpm monorepo 下 transform 问题）======
+// jest.mock must appear before imports because it is hoisted
+// ====== ESM-only dependency mocks to avoid transform issues under the pnpm monorepo======
 jest.mock("uuid", () => ({
 	v4: () => "test-uuid-" + Math.random().toString(36).slice(2, 10),
 }));
@@ -29,7 +29,7 @@ jest.mock("@repo/db", () => ({
 	Prisma: {},
 }));
 
-// ====== Mock 深层源码模块（避免递归拉入整个应用依赖树）======
+// ====== Mock deep source modules to avoid recursively loading the full app dependency tree======
 jest.mock("../../src/lib/auth", () => ({
 	auth: require("./helpers/mock-auth").mockAuth,
 }));
@@ -38,7 +38,7 @@ jest.mock("redis", () => ({
 		throw new Error("Redis not available in test");
 	}),
 }));
-// PrismaService — 只导出类 token，实际实现在 TestingModule 中覆盖
+// Prisma Service — Export only the class token; the implementation is overridden in Testing Module
 jest.mock("../../src/prisma/prisma.service", () => ({
 	PrismaService: class PrismaService {},
 }));
@@ -46,15 +46,15 @@ jest.mock("../../src/prisma/prisma.service", () => ({
 jest.mock("../../src/common/redis/redis.service", () => ({
 	RedisService: class RedisService {},
 }));
-// LeaseService — 只导出类 token
+// Lease Service — export class token only
 jest.mock("../../src/common/lease/lease.service", () => ({
 	LeaseService: class LeaseService {},
 }));
-// TaskExecutionService — 只导出类 token
+// TaskExecutionService — export class token only
 jest.mock("../../src/modules/task/task-execution.service", () => ({
 	TaskExecutionService: class TaskExecutionService {},
 }));
-// GraphRunnerService — 只导出类 token 和接口
+// GraphRunnerService — export only the class token and interface
 jest.mock("../../src/modules/graph-agent/graph-runner.service", () => ({
 	GraphRunnerService: class GraphRunnerService {},
 	CallUserResponse: class CallUserResponse {},
@@ -108,7 +108,7 @@ describe("WS Integration Tests", () => {
 		await testApp.cleanup();
 	});
 
-	// Helper: 种子化一条 PENDING execution 并设置 auth session
+	// Helper: seed one PENDING execution and set the auth session
 	function seedPendingExecution(
 		id: number,
 		userId = 1,
@@ -124,7 +124,7 @@ describe("WS Integration Tests", () => {
 		setMockSession(createUserSession(userId));
 	}
 
-	// Helper: 创建已连接客户端
+	// Helper: create a connected client
 	async function createConnectedClient(
 		executionId: number,
 		token = "valid-token",
@@ -135,24 +135,24 @@ describe("WS Integration Tests", () => {
 	}
 
 	// ============================================================
-	// 类别 1：核心主链路
+	// Category 1: core path
 	// ============================================================
 
 	describe("1. Core Happy Path", () => {
-		it("1.1 完整生命周期: connect → ready → agent:event streaming → finish", async () => {
+		it("1.1 full lifecycle: connect -> ready -> agent:event streaming -> finish", async () => {
 			seedPendingExecution(1);
 			const client = await createConnectedClient(1);
 
-			// emit execution:ready → 等待 execution:started
+			// emit execution:ready -> wait for execution:started
 			const started = await emitReadyAndWaitStarted(client, 1);
 			expect(started.executionId).toBe(1);
 			expect(testApp.mockTaskExecutionService.startExecution).toHaveBeenCalledWith(1);
 
-			// Gateway 还会自动发送 CONNECTED agent:event（seq=0）
-			// 等待该事件（可能已经到了）
+			// Gateway also automatically sends a CONNECTED agent:event (seq=0)
+			// Wait for that event, which may already have arrived
 			await delay(50);
 
-			// 发送第一个自定义 agent:event
+			// Send the first custom agent:event
 			const eventPromise1 = waitForEvent(client, "agent:event");
 			testApp.gateway.sendAgentEvent(1, {
 				type: AgentEventType.TEXT_DELTA,
@@ -161,13 +161,13 @@ describe("WS Integration Tests", () => {
 				content: "hello",
 			});
 			const event1 = await eventPromise1;
-			// seq=1 因为 seq=0 已被 CONNECTED 事件消费
+			// seq=1 because seq=0 was consumed by the CONNECTED event
 			expect(event1.seq).toBe(1);
 			expect(event1.content).toBe("hello");
 			expect(event1.type).toBe(AgentEventType.TEXT_DELTA);
 			expect(event1.timestamp).toBeDefined();
 
-			// 发送第二个 agent:event
+			// Send the second agent:event
 			const eventPromise2 = waitForEvent(client, "agent:event");
 			testApp.gateway.sendAgentEvent(1, {
 				type: AgentEventType.TEXT_DELTA,
@@ -179,7 +179,7 @@ describe("WS Integration Tests", () => {
 			expect(event2.seq).toBe(2);
 			expect(event2.content).toBe("world");
 
-			// 发送 execution:finished
+			// Send execution:finished
 			const finishPromise = waitForEvent(client, "execution:finished");
 			testApp.gateway.sendExecutionFinished(1, { status: "SUCCEED" });
 			const finished = await finishPromise;
@@ -187,7 +187,7 @@ describe("WS Integration Tests", () => {
 			expect(finished.status).toBe("SUCCEED");
 		});
 
-		it("1.2 截屏 ACK 完整往返", async () => {
+		it("1.2 screenshot ACK round trip", async () => {
 			seedPendingExecution(2);
 			testApp.mockPrisma.seedExecution({
 				id: 2,
@@ -197,7 +197,7 @@ describe("WS Integration Tests", () => {
 			});
 			const client = await createConnectedClient(2);
 
-			// 客户端监听 device:screenshot 并回传 ACK
+			// Client listens for device:screenshot and returns ACK
 			client.on("device:screenshot", (_data, callback) => {
 				callback({
 					success: true,
@@ -218,7 +218,7 @@ describe("WS Integration Tests", () => {
 			expect(result.currentAppName).toBe("com.example.app");
 		});
 
-		it("1.3 动作 ACK 完整往返", async () => {
+		it("1.3 action ACK round trip", async () => {
 			seedPendingExecution(3);
 			testApp.mockPrisma.seedExecution({
 				id: 3,
@@ -240,18 +240,18 @@ describe("WS Integration Tests", () => {
 			expect(result.success).toBe(true);
 		});
 
-		it("1.4 多事件 seq 单调递增", async () => {
+		it("1.4 multiple events keep seq monotonic", async () => {
 			seedPendingExecution(4);
 			const client = await createConnectedClient(4);
 			await emitReadyAndWaitStarted(client, 4);
 
-			// CONNECTED event 消费了 seq=0
+			// The CONNECTED event consumed seq=0
 			await delay(50);
 
 			const events: any[] = [];
 			client.on("agent:event", (data) => events.push(data));
 
-			// 快速发送 10 个事件
+			// Send 10 events quickly
 			for (let i = 0; i < 10; i++) {
 				testApp.gateway.sendAgentEvent(4, {
 					type: AgentEventType.TEXT_DELTA,
@@ -265,11 +265,11 @@ describe("WS Integration Tests", () => {
 
 			expect(events.length).toBe(10);
 			const seqs = events.map((e) => e.seq);
-			// seq 从 1 开始（0 被 CONNECTED 消费）
+			// seq starts from 1 because CONNECTED consumed 0
 			expect(seqs).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 		});
 
-		it("1.5 截屏 ACK 返回失败时抛出错误", async () => {
+		it("1.5 throws when screenshot ACK returns failure", async () => {
 			seedPendingExecution(5);
 			testApp.mockPrisma.seedExecution({
 				id: 5,
@@ -297,12 +297,12 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 2：暂停/恢复
+	// Category 2:pause/resume
 	// ============================================================
 
 	describe("2. Pause/Resume", () => {
-		it("2.1 execution:ready 识别 resume_pause 并调用 startResumeExecution", async () => {
-			// 模拟：暂停后恢复，状态已改为 PENDING + statusMessage="resume_pause"
+		it("2.1 execution:ready recognizes resume_pause and calls start Resume Execution", async () => {
+			// Simulate resume after pause with status changed to PENDING + status Message="resume_pause"
 			testApp.mockPrisma.seedExecution({
 				id: 10,
 				user_id: 1,
@@ -312,7 +312,7 @@ describe("WS Integration Tests", () => {
 			});
 			setMockSession(createUserSession(1));
 
-			// getExecutionRecord 返回带 statusMessage 的记录
+			// get Execution Record returns a record with status Message
 			testApp.mockTaskExecutionService.getExecutionRecord.mockResolvedValue({
 				id: 10,
 				executionStatus: "PENDING",
@@ -331,7 +331,7 @@ describe("WS Integration Tests", () => {
 			).not.toHaveBeenCalled();
 		});
 
-		it("2.2 execution:ready 识别 resume_hitl: 并调用 startResumeExecution(hitl)", async () => {
+		it("2.2 execution:ready recognizes resume_hitl: and calls start Resume Execution(hitl)", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 11,
 				user_id: 1,
@@ -356,7 +356,7 @@ describe("WS Integration Tests", () => {
 			).toHaveBeenCalledWith(11, "hitl");
 		});
 
-		it("2.3 execution:ready 识别 fork execution（有 originExecutionId）", async () => {
+		it("2.3 execution:ready recognizes forked execution with origin Execution Id", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 12,
 				user_id: 1,
@@ -384,17 +384,17 @@ describe("WS Integration Tests", () => {
 			).not.toHaveBeenCalled();
 		});
 
-		it("2.4 暂停后 WS 断开 → 恢复 → 重连 → ready 正确路由", async () => {
-			// Phase 1: 正常连接 + ready
+		it("2.4 after pause, WS disconnect -> resume -> reconnect -> ready routes correctly", async () => {
+			// Phase 1: normal connect + ready
 			seedPendingExecution(13);
 			const client1 = await createConnectedClient(13);
 			await emitReadyAndWaitStarted(client1, 13);
 
-			// Phase 2: 断开
+			// Phase 2: disconnect
 			client1.disconnect();
 			await delay(100);
 
-			// Phase 3: 模拟恢复后状态变为 PENDING + resume_pause
+			// Phase 3: simulate status becoming PENDING + resume_pause after resume
 			testApp.mockPrisma.seedExecution({
 				id: 13,
 				user_id: 1,
@@ -409,11 +409,11 @@ describe("WS Integration Tests", () => {
 				originExecutionId: null,
 			});
 
-			// 清理 Gateway 幂等 Set，模拟新一轮
+			// Clear the Gateway idempotency set to simulate a new round
 			(testApp.gateway as any).readyReceived.delete(13);
 			testApp.mockTaskExecutionService.startResumeExecution.mockClear();
 
-			// Phase 4: 重连
+			// Phase 4: reconnect
 			const client2 = await createConnectedClient(13);
 			await emitReadyAndWaitStarted(client2, 13);
 
@@ -424,16 +424,16 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 3：取消任务
+	// Category 3:task cancellation
 	// ============================================================
 
 	describe("3. Cancel Execution", () => {
-		it("3.1 RUNNING 状态取消 → 发送 execution:finished(CANCELLED)", async () => {
+		it("3.1 cancel in RUNNING state sends execution:finished(CANCELLED)", async () => {
 			seedPendingExecution(20);
 			const client = await createConnectedClient(20);
 			await emitReadyAndWaitStarted(client, 20);
 
-			// 模拟服务端取消完成后发通知
+			// Simulate notification after server-side cancellation finishes
 			const finishPromise = waitForEvent(client, "execution:finished");
 			testApp.gateway.sendExecutionFinished(20, {
 				status: "CANCELLED",
@@ -443,10 +443,10 @@ describe("WS Integration Tests", () => {
 			expect(finished.status).toBe("CANCELLED");
 		});
 
-		it("3.2 PENDING 状态取消 → 发送 execution:error", async () => {
+		it("3.2 cancel in PENDING state sends execution:error", async () => {
 			seedPendingExecution(21);
 			const client = await createConnectedClient(21);
-			// 不发 execution:ready
+			// Do not send execution:ready
 
 			const errorPromise = waitForEvent(client, "execution:error");
 			testApp.gateway.sendExecutionError(
@@ -457,7 +457,7 @@ describe("WS Integration Tests", () => {
 			expect(error.message).toBe("Execution cancelled before start");
 		});
 
-		it("3.3 取消后客户端收到 execution:finished 包含 summary", async () => {
+		it("3.3 after cancel, client receives execution:finished with summary", async () => {
 			seedPendingExecution(22);
 			const client = await createConnectedClient(22);
 			await emitReadyAndWaitStarted(client, 22);
@@ -472,7 +472,7 @@ describe("WS Integration Tests", () => {
 			expect(finished.message).toContain("summary");
 		});
 
-		it("3.4 execution:error 事件格式正确", async () => {
+		it("3.4 execution:error event has the correct shape", async () => {
 			seedPendingExecution(23);
 			const client = await createConnectedClient(23);
 
@@ -484,7 +484,7 @@ describe("WS Integration Tests", () => {
 			expect(error.timestamp).toBeDefined();
 		});
 
-		it("3.5 取消后立即新建 execution 可正常连接", async () => {
+		it("3.5 new execution can connect immediately after cancellation", async () => {
 			// Execution 24: cancelled
 			seedPendingExecution(24);
 			const client1 = await createConnectedClient(24);
@@ -516,18 +516,18 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 4：连接机制与边界情况
+	// Category 4:connection mechanics and edge cases
 	// ============================================================
 
 	describe("4. Connection & Edge Cases", () => {
-		it("4.1 无效 token → connect_error(Invalid authentication token)", async () => {
+		it("4.1 invalid token -> connect_error(Invalid authentication token)", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 30,
 				user_id: 1,
 				task_id: 1,
 				execution_status: "PENDING",
 			});
-			// 不设置 session → getSession 返回 null
+			// No session set -> get Session returns null
 			setMockSession(null);
 
 			const client = createClient(testApp.port, {
@@ -538,14 +538,14 @@ describe("WS Integration Tests", () => {
 			await expect(connectClient(client)).rejects.toThrow();
 		});
 
-		it("4.2 其他用户的 execution → connect_error", async () => {
+		it("4.2 another user's execution -> connect_error", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 31,
 				user_id: 1,
 				task_id: 1,
 				execution_status: "PENDING",
 			});
-			// 设置 user 2 的 session
+			// Set the session for user 2
 			setMockSession(createUserSession(2));
 
 			const client = createClient(testApp.port, {
@@ -556,7 +556,7 @@ describe("WS Integration Tests", () => {
 			await expect(connectClient(client)).rejects.toThrow();
 		});
 
-		it("4.3 已完成 execution → connect_error(FINISHED status)", async () => {
+		it("4.3 finished execution -> connect_error(FINISHED status)", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 32,
 				user_id: 1,
@@ -573,7 +573,7 @@ describe("WS Integration Tests", () => {
 			await expect(connectClient(client)).rejects.toThrow();
 		});
 
-		it("4.4 缺少 executionId → connect_error", async () => {
+		it("4.4 missing execution Id -> connect_error", async () => {
 			setMockSession(createUserSession(1));
 
 			const client = createClient(testApp.port, {
@@ -584,17 +584,17 @@ describe("WS Integration Tests", () => {
 			await expect(connectClient(client)).rejects.toThrow();
 		});
 
-		it("4.5 重复 execution:ready 幂等（只触发一次 startExecution）", async () => {
+		it("4.5 duplicate execution:ready is idempotent and triggers start Execution once", async () => {
 			seedPendingExecution(34);
 			const client = await createConnectedClient(34);
 
-			// 第一次 ready
+			// first ready
 			await emitReadyAndWaitStarted(client, 34);
 			expect(
 				testApp.mockTaskExecutionService.startExecution,
 			).toHaveBeenCalledTimes(1);
 
-			// 第二次 ready — 应被忽略
+			// second ready; should be ignored
 			client.emit("execution:ready", { executionId: 34 });
 			await delay(200);
 
@@ -603,14 +603,14 @@ describe("WS Integration Tests", () => {
 			).toHaveBeenCalledTimes(1);
 		});
 
-		it("4.6 同一 execution 旧 socket 被替换 + seq 保持连续", async () => {
+		it("4.6 old socket for the same execution is replaced and seq remains continuous", async () => {
 			seedPendingExecution(35);
 
-			// Socket A 连接
+			// Socket A connects
 			const clientA = await createConnectedClient(35);
 			await emitReadyAndWaitStarted(clientA, 35);
 
-			// CONNECTED 消费了 seq=0，再发两个事件（seq=1, seq=2）
+			// CONNECTED Consume seq=0, then send two events (seq=1, seq=2)
 			await delay(50);
 			testApp.gateway.sendAgentEvent(35, {
 				type: AgentEventType.TEXT_DELTA,
@@ -626,10 +626,10 @@ describe("WS Integration Tests", () => {
 			});
 			await delay(100);
 
-			// Socket B 连接同一 execution → A 应被断开
+			// Socket B connects to the same execution -> A should be disconnected
 			const disconnectPromise = waitForDisconnect(clientA);
 
-			// 需要新的 execution 状态允许连接（还在 RUNNING）
+			// A fresh execution state is needed to allow connection while still RUNNING
 			testApp.mockPrisma.seedExecution({
 				id: 35,
 				user_id: 1,
@@ -640,7 +640,7 @@ describe("WS Integration Tests", () => {
 			const clientB = await createConnectedClient(35);
 			await disconnectPromise;
 
-			// Socket B 发送事件 → seq 应从 3 开始（保留了 A 的 seq）
+			// Socket B sends an event -> seq should start at 3, preserving A's seq
 			const eventPromise = waitForEvent(clientB, "agent:event");
 			testApp.gateway.sendAgentEvent(35, {
 				type: AgentEventType.TEXT_DELTA,
@@ -653,7 +653,7 @@ describe("WS Integration Tests", () => {
 			expect(event.content).toBe("b1");
 		});
 
-		it("4.7 无连接时 sendAgentEvent 返回 false", async () => {
+		it("4.7 send Agent Event returns false with no connection", async () => {
 			const result = testApp.gateway.sendAgentEvent(999, {
 				type: AgentEventType.TEXT_DELTA,
 				taskExecutionId: 999,
@@ -663,13 +663,13 @@ describe("WS Integration Tests", () => {
 			expect(result).toBe(false);
 		});
 
-		it("4.8 无连接时 sendScreenshotReq 抛出错误", async () => {
+		it("4.8 send Screenshot Req throws with no connection", async () => {
 			await expect(testApp.gateway.sendScreenshotReq(999)).rejects.toThrow(
 				/No connection for execution 999/,
 			);
 		});
 
-		it("4.9 无连接时 sendActionReq 抛出错误", async () => {
+		it("4.9 send Action Req throws with no connection", async () => {
 			await expect(
 				testApp.gateway.sendActionReq(999, {
 					executionId: 999,
@@ -679,12 +679,12 @@ describe("WS Integration Tests", () => {
 			).rejects.toThrow(/No connection for execution 999/);
 		});
 
-		it("4.10 nextSeq 对未知 execution 返回 -1", () => {
+		it("4.10 next Seq returns -1 for an unknown execution", () => {
 			const seq = testApp.socketService.nextSeq(888);
 			expect(seq).toBe(-1);
 		});
 
-		it("4.11 断开后 removeConnectionBySocketId 正确清理", async () => {
+		it("4.11 remove Connection BySocket Id cleans up after disconnect", async () => {
 			seedPendingExecution(36);
 			const client = await createConnectedClient(36);
 
@@ -699,11 +699,11 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 5：心跳与租约
+	// Category 5:heartbeats and leases
 	// ============================================================
 
 	describe("5. Heartbeat & Lease", () => {
-		it("5.1 心跳正常续租 → { renewed: true }", async () => {
+		it("5.1 heartbeat renews lease normally -> { renewed: true }", async () => {
 			seedPendingExecution(40);
 			const client = await createConnectedClient(40);
 
@@ -719,7 +719,7 @@ describe("WS Integration Tests", () => {
 			expect(testApp.mockLeaseService.renewLease).toHaveBeenCalledWith(40);
 		});
 
-		it("5.2 心跳重建过期 lease（执行仍活跃）", async () => {
+		it("5.2 heartbeat rebuilds expired lease while execution remains active", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 41,
 				user_id: 1,
@@ -728,10 +728,10 @@ describe("WS Integration Tests", () => {
 			});
 			setMockSession(createUserSession(1));
 
-			// renewLease 返回 false（lease 过期）
+			// renew Lease returns false because the lease expired
 			testApp.mockLeaseService.renewLease.mockResolvedValue(false);
 
-			// getExecutionRecord 返回活跃状态
+			// get Execution Record returns an active status
 			testApp.mockTaskExecutionService.getExecutionRecord.mockResolvedValue({
 				id: 41,
 				executionStatus: "RUNNING",
@@ -752,19 +752,19 @@ describe("WS Integration Tests", () => {
 			expect(testApp.mockLeaseService.createLease).toHaveBeenCalled();
 		});
 
-		it("5.3 心跳失败且 execution 非活跃 → 断开客户端", async () => {
+		it("5.3 heartbeat failure with inactive execution disconnects the client", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 42,
 				user_id: 1,
 				task_id: 1,
-				execution_status: "RUNNING", // Auth middleware 需要可连接状态
+				execution_status: "RUNNING", // Auth middleware requires a connectable status.
 			});
 			setMockSession(createUserSession(1));
 
-			// renewLease 返回 false
+			// renew Lease returns false
 			testApp.mockLeaseService.renewLease.mockResolvedValue(false);
 
-			// getExecutionRecord 返回 FINISHED（不再活跃）
+			// get Execution Record returns FINISHED and is no longer active
 			testApp.mockTaskExecutionService.getExecutionRecord.mockResolvedValue({
 				id: 42,
 				executionStatus: "FINISHED",
@@ -780,7 +780,7 @@ describe("WS Integration Tests", () => {
 			expect(reason).toBeDefined();
 		});
 
-		it("5.4 SUSPENDED 状态心跳可重建 lease", async () => {
+		it("5.4 heartbeat can rebuild lease in SUSPENDED state", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 43,
 				user_id: 1,
@@ -812,11 +812,11 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 6：超时测试
+	// Category 6:timeouts Test
 	// ============================================================
 
 	describe("6. Timeouts", () => {
-		it("6.1 截屏 ACK 超时（客户端不回复）", async () => {
+		it("6.1 screenshot ACK timeout when the client does not respond", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 50,
 				user_id: 1,
@@ -826,18 +826,18 @@ describe("WS Integration Tests", () => {
 			setMockSession(createUserSession(1));
 			const client = await createConnectedClient(50);
 
-			// 客户端监听 device:screenshot 但不回复 callback
+			// Client listens for device:screenshot but does not call back
 
-			// sendScreenshotReq 内部有 15s 超时
-			// 为了测试不等那么久，我们验证 Promise 行为
+			// sendScreenshotReq has an internal 15s timeout
+			// To avoid waiting that long in the test, verify the Promise behavior
 			const screenshotPromise = testApp.gateway.sendScreenshotReq(50);
 
-			// 这个 Promise 会因超时 reject，但需要等 15s
-			// 测试标注：此测试需要较长时间（~15s），在 CI 中可能需要跳过
+			// This Promise rejects on timeout, but that takes 15s
+			// Test note: this test takes longer (~15s) and may need to be skipped in CI
 			await expect(screenshotPromise).rejects.toThrow();
 		}, 20000);
 
-		it("6.2 动作 ACK 超时（客户端不回复）", async () => {
+		it("6.2 action ACK timeout when the client does not respond", async () => {
 			testApp.mockPrisma.seedExecution({
 				id: 51,
 				user_id: 1,
@@ -856,7 +856,7 @@ describe("WS Integration Tests", () => {
 			await expect(actionPromise).rejects.toThrow();
 		}, 15000);
 
-		it("6.3 execution:ready 失败时发送 execution:error", async () => {
+		it("6.3 sends execution:error when execution:ready fails", async () => {
 			seedPendingExecution(52);
 
 			testApp.mockTaskExecutionService.startExecution.mockRejectedValue(
@@ -881,19 +881,19 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别 7：竞态条件
+	// Category 7:race conditions
 	// ============================================================
 
 	describe("7. Race Conditions", () => {
-		it("7.1 startExecution CAS 失败（expected PENDING）但已 RUNNING → 发送 started", async () => {
+		it("7.1 start Execution CAS fails with expected PENDING but already RUNNING -> sends started", async () => {
 			seedPendingExecution(60);
 
-			// startExecution 抛出 CAS 失败错误
+			// start Execution throws a CAS failure
 			testApp.mockTaskExecutionService.startExecution.mockRejectedValue(
 				new Error("CAS failed: expected PENDING but found RUNNING"),
 			);
 
-			// getExecutionRecord 返回 RUNNING（模拟另一方已启动）
+			// get Execution Record returns RUNNING to simulate another starter
 			testApp.mockTaskExecutionService.getExecutionRecord.mockResolvedValue({
 				id: 60,
 				executionStatus: "RUNNING",
@@ -903,14 +903,14 @@ describe("WS Integration Tests", () => {
 
 			const client = await createConnectedClient(60);
 
-			// 应该收到 execution:started 而不是 error
+			// Should receive execution:started instead of error
 			const startedPromise = waitForEvent(client, "execution:started");
 			client.emit("execution:ready", { executionId: 60 });
 			const started = await startedPromise;
 			expect(started.executionId).toBe(60);
 		});
 
-		it("7.2 startExecution CAS 失败且非 RUNNING → 发送 error", async () => {
+		it("7.2 start Execution CAS fails and status is not RUNNING -> sends error", async () => {
 			seedPendingExecution(61);
 
 			testApp.mockTaskExecutionService.startExecution.mockRejectedValue(
@@ -932,10 +932,10 @@ describe("WS Integration Tests", () => {
 			expect(error.message).toContain("expected PENDING");
 		});
 
-		it("7.3 多个客户端快速连接同一 execution → 只有最后一个存活", async () => {
+		it("7.3 multiple clients quickly connect to the same execution -> only the last survives", async () => {
 			seedPendingExecution(62);
 
-			// 同时创建 3 个客户端
+			// Create 3 clients concurrently
 			const clients = await Promise.all([
 				createConnectedClient(62),
 				(async () => {
@@ -950,11 +950,11 @@ describe("WS Integration Tests", () => {
 
 			await delay(300);
 
-			// 只有最后一个应该保持连接
+			// Only the last one should remain connected
 			const connectedCount = clients.filter((c) => c.connected).length;
 			expect(connectedCount).toBe(1);
 
-			// 最后连接的应该可以收到事件
+			// The last connected client should receive events
 			const lastClient = clients[2];
 			if (lastClient.connected) {
 				const eventPromise = waitForEvent(lastClient, "agent:event");
@@ -969,16 +969,16 @@ describe("WS Integration Tests", () => {
 			}
 		});
 
-		it("7.4 断开 → 立即重连 → execution:ready 正常工作", async () => {
+		it("7.4 disconnect -> immediate reconnect -> execution:ready still works", async () => {
 			seedPendingExecution(63);
 			const client1 = await createConnectedClient(63);
 			await emitReadyAndWaitStarted(client1, 63);
 
-			// 断开
+			// disconnect
 			client1.disconnect();
 			await delay(100);
 
-			// 重连（execution 仍在 RUNNING）
+			// Reconnect while execution is still RUNNING
 			testApp.mockPrisma.seedExecution({
 				id: 63,
 				user_id: 1,
@@ -989,7 +989,7 @@ describe("WS Integration Tests", () => {
 			const client2 = await createConnectedClient(63);
 			expect(client2.connected).toBe(true);
 
-			// sendAgentEvent 正常工作
+			// send Agent Event works normally
 			const eventPromise = waitForEvent(client2, "agent:event");
 			testApp.gateway.sendAgentEvent(63, {
 				type: AgentEventType.TEXT_DELTA,
@@ -1003,7 +1003,7 @@ describe("WS Integration Tests", () => {
 	});
 
 	// ============================================================
-	// 类别补充：ExecutionSocketService 单元级测试
+	// Additional category: ExecutionSocketService unit-level tests
 	// ============================================================
 
 	describe("8. ExecutionSocketService Internals", () => {
@@ -1017,7 +1017,7 @@ describe("WS Integration Tests", () => {
 			expect(conn!.seq).toBe(0);
 		});
 
-		it("8.2 isConnected 在连接/断开后正确返回", async () => {
+		it("8.2 is Connected returns correctly after connect/disconnect", async () => {
 			seedPendingExecution(71);
 			expect(testApp.socketService.isConnected(71)).toBe(false);
 
@@ -1029,7 +1029,7 @@ describe("WS Integration Tests", () => {
 			expect(testApp.socketService.isConnected(71)).toBe(false);
 		});
 
-		it("8.3 getActiveCount 正确计数", async () => {
+		it("8.3 get Active Count counts correctly", async () => {
 			const initialCount = testApp.socketService.getActiveCount();
 
 			seedPendingExecution(72);
@@ -1054,7 +1054,7 @@ describe("WS Integration Tests", () => {
 			expect(testApp.socketService.getActiveCount()).toBe(initialCount);
 		});
 
-		it("8.4 getSocketForExecution 返回 socket 或 null", async () => {
+		it("8.4 get Socket For Execution returns a socket or null", async () => {
 			expect(testApp.socketService.getSocketForExecution(999)).toBeNull();
 
 			seedPendingExecution(74);


### PR DESCRIPTION
## Summary

- Translate Chinese code comments, KDoc/JSDoc, and server test describe/it names to English across client and server.
- Keep runtime Chinese strings intact where they are user-visible copy, real-app UI matching text, logs, errors, or mock/prompt/sample data.
- Document the public-release convention in AGENTS.md so future code comments and test names stay English.

## Validation

- PASS: Chinese comment residual check returned 0.
- PASS: server describe/it title Chinese residual check returned 0.
- PASS: git diff --check.
- PASS: cd client && ./gradlew :automation:compileDebugKotlin :core_common:compileDebugKotlin :core_aop:compileKotlin.

## Known existing validation failures

- cd server && pnpm run format-and-lint fails on existing repository-wide Biome issues, including schema version mismatch, existing formatting drift, import type warnings, and noExplicitAny warnings.
- cd server && pnpm --filter backend test fails outside this comment-cleanup change: post-execute tests still expect Chinese cycle-reason substrings while the implementation returns English, and plan-supervisor integration tests call DashScope with an invalid/placeholder API key and receive 401.
