### PR TITLE
[codex] Add GitHub star CTA and README news

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -14,6 +14,18 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="手動セットアップドキュメント"></a>
 </p>
 
+<p align="center">
+  OpenGUI が実機 Android エージェントの構築やテストに役立った場合は、<a href="https://github.com/Core-Mate/open-gui">GitHub Star でプロジェクトの成長を応援してください</a>。
+</p>
+
+## 📣 最近の更新
+
+- `[2026.5.7]` README、バックエンド起動出力、Android 設定画面、初回タスク成功後の軽い案内に GitHub Star への導線を追加しました。
+- `[2026.5.7]` Docker ベースのバックエンド起動時に、一般的な PostgreSQL / Redis ポート競合を避けられるようローカル起動フローを強化しました。
+- `[2026.5.2]` ソース公開版として読みやすくするため、公開コードコメントと開発者向け文言を英語化しました。
+- `[2026.5.1]` バックエンドのオンボーディングとして、`.env.example`、起動時チェック、graph agent 向け VLM 環境変数設定を整備しました。
+- `[2026.4.30]` 日本語 README を追加し、ライセンスを BUSL-1.1 に切り替え、公開 Android UI とプロンプトを英語化しました。
+
 ## OpenGUI でできること
 
 OpenGUI は、AI が実際の Android スマートフォンを操作できるようにするシステムです。

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="Manual setup docs"></a>
 </p>
 
+<p align="center">
+  If OpenGUI helps you build or test real Android agents, <a href="https://github.com/Core-Mate/open-gui">a GitHub star helps the project grow</a>.
+</p>
+
+## 📣 News
+
+- `[2026.5.7]` OpenGUI added GitHub Star CTA touchpoints across the README, backend startup output, Android settings, and the first successful phone task prompt.
+- `[2026.5.7]` Local startup was hardened to avoid common PostgreSQL and Redis port conflicts during Docker-based backend setup.
+- `[2026.5.2]` Public code comments and developer-facing copy were translated to English for a cleaner source-available release.
+- `[2026.5.1]` Backend onboarding was improved with a completed `.env.example`, clearer startup checks, and graph-agent VLM environment configuration.
+- `[2026.4.30]` OpenGUI added a Japanese README and switched the project license to BUSL-1.1 while translating public Android UI and prompts to English.
+
 ## What You Can Do with OpenGUI
 
 OpenGUI lets AI operate real Android phones.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,18 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="Manual setup docs"></a>
 </p>
 
+<p align="center">
+  如果 OpenGUI 帮你构建或测试真实 Android Agent，<a href="https://github.com/Core-Mate/open-gui">给项目一个 GitHub Star 会帮助它继续成长</a>。
+</p>
+
+## 📣 近期更新
+
+- `[2026.5.7]` OpenGUI 在 README、后端启动输出、Android 设置页和首次成功执行任务后的轻提示中加入 GitHub Star 入口。
+- `[2026.5.7]` 本地启动流程增强，Docker 方式启动后端时会避开常见的 PostgreSQL 和 Redis 端口冲突。
+- `[2026.5.2]` 公开代码注释和面向开发者的文案完成英文化，便于源码可见版本对外发布。
+- `[2026.5.1]` 后端上手流程补齐 `.env.example`、启动检查提示和 graph agent 的 VLM 环境变量配置。
+- `[2026.4.30]` OpenGUI 新增日文 README，并将项目许可证切换到 BUSL-1.1，同时把公开 Android UI 和 Prompt 翻译为英文。
+
 ## 你可以用 OpenGUI 做什么
 
 OpenGUI 让 AI 操作真实的 Android 手机。

--- a/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/mine/setting/SettingActivity.kt
+++ b/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/mine/setting/SettingActivity.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.widget.Toast
 import com.coremate.opengui.feature.promotor.databinding.ActivitySettingBinding
 import com.coremate.opengui.feature.promotor.ui.base.BaseBindingActivity
+import com.coremate.opengui.feature.promotor.util.GitHubStarHelper
 import com.coremate.opengui.network.api.ServerConstant
 import com.tencent.mmkv.MMKV
 
@@ -28,6 +29,9 @@ class SettingActivity :
 
     override fun initEvent() {
         binding.btnBack.setOnClickListener { finish() }
+        binding.layoutStarGithub.setOnClickListener {
+            GitHubStarHelper.openRepository(this)
+        }
 
         binding.btnSave.setOnClickListener {
             val url = binding.etServerUrl.text.toString().trim()

--- a/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/summarizer/SummarizerActivity.kt
+++ b/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/summarizer/SummarizerActivity.kt
@@ -47,6 +47,7 @@ import com.coremate.opengui.feature.promotor.ui.markdown.TableEntry
 import com.coremate.opengui.feature.promotor.ui.markdown.TableEntryPlugin
 import com.coremate.opengui.feature.promotor.ui.markdown.XMNotTableEntry
 import com.coremate.opengui.feature.promotor.ui.markdown.latex.JLatexMathPlugin
+import com.coremate.opengui.feature.promotor.util.GitHubStarHelper
 import com.coremate.opengui.feature.promotor.util.calculateDuration
 import com.coremate.opengui.network.api.task.Extra
 import io.noties.markwon.AbstractMarkwonPlugin
@@ -329,11 +330,28 @@ class SummarizerActivity :
                         it.executionResultSummary ?: "No feedback for this task"
                     )
                     markwonAdapter?.notifyDataSetChanged()
+                    if (it.executionResult == "SUCCEED") {
+                        maybeShowFirstSuccessStarPrompt()
+                    }
                 }
             }.onFailure {
                 it.printStackTrace()
             }
         }
+    }
+
+    private fun maybeShowFirstSuccessStarPrompt() {
+        if (!GitHubStarHelper.shouldShowFirstSuccessPrompt(this)) {
+            return
+        }
+        GitHubStarHelper.markFirstSuccessPromptShown(this)
+        AlertDialog.Builder(this)
+            .setMessage("OpenGUI just completed its first phone task. If this helped, star the project on GitHub.")
+            .setPositiveButton("Star on GitHub") { _, _ ->
+                GitHubStarHelper.openRepository(this)
+            }
+            .setNegativeButton("Maybe later", null)
+            .show()
     }
 
     fun exportRecyclerViewToPdf(recyclerView: RecyclerView, pdfFile: File) {

--- a/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/task/MyTaskFragment.kt
+++ b/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/ui/task/MyTaskFragment.kt
@@ -12,8 +12,9 @@ import androidx.recyclerview.widget.RecyclerView
 import com.coremate.opengui.common_jvm.event.AutomationEvent
 import com.coremate.opengui.common_jvm.event.AutomationEventBus
 import com.coremate.opengui.feature.promotor.databinding.FragmentMyTaskBinding
-import com.coremate.opengui.feature.promotor.ui.widget.ContentStartBigTitleBar
 import com.coremate.opengui.feature.promotor.ui.task.adapter.ExecutedTaskListAdapter
+import com.coremate.opengui.feature.promotor.ui.widget.ContentStartBigTitleBar
+import com.coremate.opengui.feature.promotor.util.GitHubStarHelper
 import com.coremate.opengui.network.api.task.TaskListRespItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
@@ -47,6 +48,12 @@ class MyTaskFragment : Fragment() {
         taskListAdapter = ExecutedTaskListAdapter(fragmentManager, presenter)
         binding.rvTaskList.adapter = taskListAdapter;
         binding.rvTaskList.layoutManager = LinearLayoutManager(requireContext())
+        binding.layoutGithubStar.setOnClickListener {
+            GitHubStarHelper.openRepository(requireContext())
+        }
+        binding.btnGithubStar.setOnClickListener {
+            GitHubStarHelper.openRepository(requireContext())
+        }
 
         binding.rvTaskList.addOnScrollListener(object : RecyclerView.OnScrollListener() {
             override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {

--- a/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/util/GitHubStarHelper.kt
+++ b/client/feature_promotor/src/main/java/com/coremate/opengui/feature/promotor/util/GitHubStarHelper.kt
@@ -1,0 +1,38 @@
+package com.coremate.opengui.feature.promotor.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
+
+object GitHubStarHelper {
+    private const val REPOSITORY_URL = "https://github.com/Core-Mate/open-gui"
+    private const val PREF_NAME = "opengui_star_cta"
+    private const val KEY_FIRST_SUCCESS_PROMPT_SHOWN = "first_success_prompt_shown"
+
+    fun openRepository(context: Context) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(REPOSITORY_URL)).apply {
+            if (context !is Activity) {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        }
+        runCatching {
+            context.startActivity(intent)
+        }.onFailure {
+            Toast.makeText(context, "Could not open GitHub", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun shouldShowFirstSuccessPrompt(context: Context): Boolean {
+        return !context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+            .getBoolean(KEY_FIRST_SUCCESS_PROMPT_SHOWN, false)
+    }
+
+    fun markFirstSuccessPromptShown(context: Context) {
+        context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_FIRST_SUCCESS_PROMPT_SHOWN, true)
+            .apply()
+    }
+}

--- a/client/feature_promotor/src/main/res/layout/activity_setting.xml
+++ b/client/feature_promotor/src/main/res/layout/activity_setting.xml
@@ -89,6 +89,50 @@
             android:textSize="14sp" />
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/layout_star_github"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="16dp"
+        android:background="@drawable/me_settings_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Star on GitHub"
+                android:textColor="#111827"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="Support OpenGUI and follow updates"
+                android:textColor="#9CA3AF"
+                android:textSize="12sp" />
+        </LinearLayout>
+
+        <ImageView
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:contentDescription="Open GitHub"
+            android:src="@drawable/ic_my_arrow_right" />
+    </LinearLayout>
+
 
     <View
         android:layout_width="match_parent"

--- a/client/feature_promotor/src/main/res/layout/fragment_my_task.xml
+++ b/client/feature_promotor/src/main/res/layout/fragment_my_task.xml
@@ -16,9 +16,56 @@
         app:searchActionInPage="true"
         app:title="My Tasks" />
 
+    <LinearLayout
+        android:id="@+id/layout_github_star"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="12dp"
+        android:background="@drawable/me_settings_bg"
+        android:clickable="true"
+        android:focusable="true"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="OpenGUI is open on GitHub"
+            android:textColor="#111827"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="Build, test, and follow the Android agent runtime."
+            android:textColor="#6B7280"
+            android:textSize="13sp" />
+
+        <TextView
+            android:id="@+id/btn_github_star"
+            android:layout_width="wrap_content"
+            android:layout_height="36dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/add_task_gradient"
+            android:gravity="center"
+            android:minWidth="132dp"
+            android:paddingStart="18dp"
+            android:paddingEnd="18dp"
+            android:text="Star on GitHub"
+            android:textColor="#ffffff"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_task_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
 </LinearLayout>

--- a/server/apps/backend/.env.example
+++ b/server/apps/backend/.env.example
@@ -6,11 +6,11 @@ NODE_ENV=development
 PORT=7777
 
 # Database (matches docker defaults)
-DATABASE_URL=postgresql://opengui:opengui@localhost:5432/opengui
+DATABASE_URL=postgresql://opengui:opengui@127.0.0.1:55432/opengui
 
 # Redis (matches docker defaults)
-REDIS_HOST=localhost
-REDIS_PORT=6379
+REDIS_HOST=127.0.0.1
+REDIS_PORT=56379
 REDIS_DB=0
 REDIS_PASSWORD=
 

--- a/server/apps/backend/src/main.ts
+++ b/server/apps/backend/src/main.ts
@@ -45,9 +45,10 @@ async function bootstrap() {
 	const port = process.env.PORT ?? 7777;
 	await app.listen(port);
 
-	console.log(
-		`📚 API Documentation available at: http://localhost:${port}/docs`,
-	);
+	const docsUrl = `http://localhost:${port}/docs`;
+	console.log(`📚 API Documentation available at: ${docsUrl}`);
+	console.log("⭐ If this project helps, star it here:");
+	console.log("   https://github.com/Core-Mate/open-gui");
 }
 
 bootstrap();

--- a/server/start.sh
+++ b/server/start.sh
@@ -32,14 +32,24 @@ info "Node.js $(node -v) / pnpm $(pnpm -v)"
 # --------------------------------------------------
 # 2. Start PostgreSQL + Redis (docker run)
 # --------------------------------------------------
+POSTGRES_HOST_PORT=55432
+REDIS_HOST_PORT=56379
+
 if docker ps --format '{{.Names}}' | grep -q "^opengui-postgres$"; then
-  info "PostgreSQL is already running"
-else
+  if docker port opengui-postgres 5432/tcp 2>/dev/null | grep -q ":${POSTGRES_HOST_PORT}$"; then
+    info "PostgreSQL is already running"
+  else
+    warn "Recreating PostgreSQL with host port ${POSTGRES_HOST_PORT} ..."
+    docker rm -f opengui-postgres >/dev/null
+  fi
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -q "^opengui-postgres$"; then
   warn "Starting PostgreSQL ..."
   docker rm -f opengui-postgres 2>/dev/null || true
   docker run -d \
     --name opengui-postgres \
-    -p 5432:5432 \
+    -p ${POSTGRES_HOST_PORT}:5432 \
     -e POSTGRES_USER=opengui \
     -e POSTGRES_PASSWORD=opengui \
     -e POSTGRES_DB=opengui \
@@ -62,13 +72,20 @@ else
 fi
 
 if docker ps --format '{{.Names}}' | grep -q "^opengui-redis$"; then
-  info "Redis is already running"
-else
+  if docker port opengui-redis 6379/tcp 2>/dev/null | grep -q ":${REDIS_HOST_PORT}$"; then
+    info "Redis is already running"
+  else
+    warn "Recreating Redis with host port ${REDIS_HOST_PORT} ..."
+    docker rm -f opengui-redis >/dev/null
+  fi
+fi
+
+if ! docker ps --format '{{.Names}}' | grep -q "^opengui-redis$"; then
   warn "Starting Redis ..."
   docker rm -f opengui-redis 2>/dev/null || true
   docker run -d \
     --name opengui-redis \
-    -p 6379:6379 \
+    -p ${REDIS_HOST_PORT}:6379 \
     -v opengui-redisdata:/data \
     redis:7-alpine >/dev/null
   info "Redis started"
@@ -208,8 +225,7 @@ fi
 # --------------------------------------------------
 info "Starting OpenGUI Server ..."
 echo ""
-echo "  API:  http://localhost:${PORT:-7777}/api"
-echo "  Docs: http://localhost:${PORT:-7777}/docs"
+echo "  The backend will print API docs and GitHub star links after startup."
 echo ""
 
 pnpm backend


### PR DESCRIPTION
## Summary

- Add GitHub Star CTA touchpoints to the README, Android home/settings UI, and the first successful task prompt.
- Add recent update/news sections to English, Chinese, and Japanese READMEs.
- Polish backend startup output and `.env.example` defaults for Docker-based local services.

## Validation

- Ran `git diff --cached --check` before commit.
- Scanned the changed public files for API keys, GitHub tokens, personal paths/emails, old internal package names, and local hotspot IP leakage.
- Kept the locally built APK out of this code PR.
