### PR TITLE
[codex] Add Discord IM channel

### DIFF
--- a/DISCORD.ja-JP.md
+++ b/DISCORD.ja-JP.md
@@ -1,0 +1,535 @@
+<p align="center">
+  <strong>言語:</strong> <a href="./DISCORD.md">English</a> | <a href="./DISCORD.zh-CN.md">简体中文</a> | <a href="./DISCORD.ja-JP.md">日本語</a>
+</p>
+
+# Discord リモートコントロール
+
+Discord は OpenGUI の任意のリモートコマンド入口として利用できます。Bot が
+Discord チャンネルのコマンドを受け取り、バックエンドが OpenGUI タスクを作成または実行し、
+スタンバイ中の Android 端末にディスパッチします。
+
+Discord はコマンド入力面です。Bot が Discord アプリの UI を直接操作するわけではありません。
+
+```text
+Discord チャンネル
+  -> Discord bot
+  -> OpenGUI バックエンド
+  -> スタンバイ中の Android 端末
+  -> 同じ Discord チャンネルへ結果を返す
+```
+
+## はじめる前に
+
+この機能は、Discord チャンネルを OpenGUI のリモートコマンド入口にします。
+
+たとえば Discord で次のように送信します:
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+バックエンドがこのコマンドを受け取り、OpenGUI タスクを作成し、スタンバイ中の Android
+端末にディスパッチします。
+
+この機能が行わないこと:
+
+- Discord Web、Mac、Windows クライアントの UI を自動操作しません。
+- OpenGUI Android アプリを置き換えません。実際の端末操作は Android クライアントが行います。
+- Discord 専用の Android APK は不要です。
+
+必要なもの:
+
+- Discord アカウント。
+- 管理権限のある Discord server。なければテスト用 server を作成できます。
+- 起動できる OpenGUI バックエンド。
+- バックエンドにスタンバイ接続している Android 端末。
+
+## 1. Discord Server を作成または準備する
+
+すでにテスト用 server がある場合は、この節をスキップできます。
+
+作成する場合:
+
+1. Discord を開きます。
+2. 左側の server 一覧で `+` をクリックします。
+3. **Create My Own** を選択します。
+4. **For me and my friends**、または近い選択肢を選びます。
+5. `opengui-test` などの server 名を入力します。
+6. デフォルトのテキストチャンネルを開きます。通常は `general` です。
+
+Bot はこの server に招待され、このテキストチャンネルでコマンドを受け取ります。
+
+## 2. Discord Application を作成する
+
+1. https://discord.com/developers/applications を開きます。
+2. **New Application** をクリックします。
+3. `OpenGUITest` などの名前を入力します。
+4. 利用規約に同意し、**Create** をクリックします。
+
+application は Discord 側の bot プロジェクトです。Bot、Client ID、OAuth2 招待 URL
+はここで管理します。
+
+## 3. Application ID をコピーする
+
+1. application ページで **General Information** を開きます。
+2. **Application ID** を探します。
+3. **Copy** をクリックします。
+4. この値を次に設定します:
+
+```env
+DISCORD_CLIENT_ID=your_application_id
+```
+
+ここで使うのは **Application ID** です。Public Key、server ID、channel ID ではありません。
+
+## 4. Bot を作成し Token をコピーする
+
+1. 左側の **Bot** を開きます。
+2. Bot 作成を求められた場合は **Add Bot** などのボタンをクリックします。
+3. **Token** セクションを探します。
+4. **Reset Token** または **Copy** をクリックします。
+5. Discord が認証を求める場合があります。
+6. コピーした token を次に設定します:
+
+```env
+DISCORD_BOT_TOKEN=your_bot_token
+```
+
+Token は bot のパスワードです:
+
+- Git にコミットしないでください。
+- README に書かないでください。
+- 信頼できない相手に共有しないでください。
+- 漏えいした場合は Bot ページで **Reset Token** を実行してください。
+
+## 5. Message Content Intent を有効にする
+
+同じ **Bot** ページで **Privileged Gateway Intents** までスクロールします。
+
+有効にするのはこれだけです:
+
+```text
+Message Content Intent
+```
+
+これは次のような prefix command を読むために必要です:
+
+```text
+!opengui help
+!opengui devices
+!opengui do ...
+```
+
+不要なもの:
+
+```text
+Presence Intent
+Server Members Intent
+```
+
+OpenGUI のコマンドフローではメンバー一覧やオンライン状態を読みません。
+
+## 6. 招待 URL を生成する
+
+1. 左側の **OAuth2** を開きます。
+2. **URL Generator** を開きます。
+3. **Scopes** で次を選択します:
+
+```text
+bot
+applications.commands
+```
+
+どちらも必要です:
+
+- `bot`: bot を server に参加させ、メッセージ送信を可能にします。
+- `applications.commands`: `/opengui` の slash command を有効にします。
+
+4. **Bot Permissions** までスクロールします。
+5. 次を選択します:
+
+```text
+View Channels
+Send Messages
+Read Message History
+Use Slash Commands
+```
+
+権限の意味:
+
+- View Channels: bot がチャンネルを見られます。
+- Send Messages: bot が返信できます。
+- Read Message History: bot がメッセージ履歴を読めます。
+- Use Slash Commands: bot が `/opengui` コマンドを提供できます。
+
+**Administrator** をデフォルト手順として使うのは避けてください。短いテストでは便利ですが、
+OpenGUI に必要な権限より大きすぎます。
+
+6. ページ下部の生成 URL をコピーします。
+7. ブラウザで開きます。
+8. テスト用 server を選択します。
+9. **Authorize** をクリックします。
+10. 認証を完了します。
+
+server のメンバー一覧に bot が表示されれば招待成功です。
+
+招待直後の bot がオフラインでも正常です。バックエンドが token で Discord にログインすると
+オンラインになります。
+
+## 7. Discord Developer Mode を有効にする
+
+server、channel、user ID をコピーする必要があります。Discord は標準では **Copy ID** を
+隠していることがあります。
+
+有効化手順:
+
+1. Discord を開きます。
+2. 左下のプロフィール付近にある歯車アイコンをクリックします。
+3. **Advanced** を開きます。
+4. **Developer Mode** を有効にします。
+
+これで server、channel、user の右クリックメニューに **Copy ID** が表示されます。
+
+## 8. Server ID、Channel ID、User ID をコピーする
+
+`.env` には 3 つの ID が必要です。
+
+### Server ID
+
+1. 左側の server 一覧でテスト用 server アイコンを右クリックします。
+2. **Copy Server ID** または **Copy ID** をクリックします。
+3. 次に設定します:
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=your_server_id
+```
+
+Discord API では server を guild と呼ぶため、環境変数名は `GUILD_IDS` です。
+
+### Channel ID
+
+1. コマンドを送るテキストチャンネル、たとえば `#general` を右クリックします。
+2. **Copy Channel ID** または **Copy ID** をクリックします。
+3. 次に設定します:
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=your_channel_id
+```
+
+### User ID
+
+1. server のメンバー一覧で自分を探します。
+2. 自分のアバターまたはユーザー名を右クリックします。
+3. **Copy User ID** または **Copy ID** をクリックします。
+4. 次に設定します:
+
+```env
+DISCORD_ALLOWED_USER_IDS=your_user_id
+```
+
+この allowlist により、他のユーザーが勝手に端末タスクを実行することを防げます。
+
+## 環境変数
+
+以下を `server/apps/backend/.env` に追加します:
+
+```env
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=false
+```
+
+最初に slash command をテストする場合は次にします:
+
+```env
+DISCORD_REGISTER_COMMANDS=true
+```
+
+これにより、バックエンド起動時に `/opengui` コマンドが設定済み guild に登録されます。
+
+slash command の登録後は、次に戻せます:
+
+```env
+DISCORD_REGISTER_COMMANDS=false
+```
+
+allowlist の動作:
+
+- 空の allowlist は、その次元では制限しないことを意味します。
+- 空でない allowlist では、guild、channel、または user が一致する必要があります。
+- 本番環境や共有テスト環境では、少なくとも `DISCORD_ALLOWED_GUILD_IDS` と
+  `DISCORD_ALLOWED_CHANNEL_IDS` を設定してください。
+- `DISCORD_REGISTER_COMMANDS=true` には `DISCORD_CLIENT_ID` と
+  `DISCORD_ALLOWED_GUILD_IDS` が必要です。
+
+ID の対応:
+
+| 変数 | Discord での取得元 |
+|---|---|
+| `DISCORD_CLIENT_ID` | Developer Portal -> General Information -> Application ID |
+| `DISCORD_ALLOWED_GUILD_IDS` | Discord server ID |
+| `DISCORD_ALLOWED_CHANNEL_IDS` | Discord text channel ID |
+| `DISCORD_ALLOWED_USER_IDS` | Discord user ID |
+
+ローカルテスト例:
+
+```env
+DISCORD_BOT_TOKEN=your_bot_token
+DISCORD_CLIENT_ID=your_application_id
+DISCORD_ALLOWED_GUILD_IDS=your_server_id
+DISCORD_ALLOWED_CHANNEL_IDS=your_channel_id
+DISCORD_ALLOWED_USER_IDS=your_user_id
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=true
+```
+
+複数の ID はカンマ区切りで指定できます:
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=channel_id_1,channel_id_2
+DISCORD_ALLOWED_USER_IDS=user_id_1,user_id_2
+```
+
+## 9. バックエンドを再起動する
+
+`.env` を変更した後はバックエンドを再起動してください。環境変数は通常、プロセス起動時に
+一度だけ読み込まれます。
+
+バックエンドが起動中なら、ターミナルで次を押します:
+
+```bash
+Ctrl + C
+```
+
+その後、再起動します:
+
+```bash
+cd server
+pnpm backend
+```
+
+または:
+
+```bash
+cd server
+./start.sh
+```
+
+成功時のログ例:
+
+```text
+IM channel: Discord bot registered
+[DiscordBot] Connected as OpenGUITest#3874
+```
+
+`DISCORD_REGISTER_COMMANDS=true` の場合は、次のようなログも出ます:
+
+```text
+[DiscordBot] Slash commands registered for guild 1234567890
+```
+
+次のログが出る場合:
+
+```text
+Discord bot not configured, skipping
+```
+
+バックエンドが `DISCORD_BOT_TOKEN` を読めていないか、`.env` の場所が想定と違います。
+
+## 10. Android 端末がオンラインか確認する
+
+Discord は入口です。実際に操作するのは Android 端末です。
+
+タスク送信前に確認してください:
+
+- OpenGUI バックエンドが起動している。
+- OpenGUI Android アプリが開いている。
+- 端末がバックエンドに接続している。
+- バックエンドログに `Device registered` のような表示がある。
+
+Discord でも確認できます:
+
+```text
+!opengui devices
+```
+
+次のような端末モデルが出ればオンラインです:
+
+```text
+OPPO PGEM10
+```
+
+## コマンド
+
+Prefix commands:
+
+```text
+!opengui help
+!opengui devices
+!opengui do open browser and search OpenGUI
+!opengui run 123
+!opengui status
+!opengui status 456
+!opengui cancel 456
+!opengui pause 456
+!opengui resume 456 continue
+```
+
+Slash commands:
+
+```text
+/opengui help
+/opengui devices
+/opengui do task:open browser and search OpenGUI
+/opengui run task_id:123
+/opengui status execution_id:456
+/opengui cancel execution_id:456
+/opengui pause execution_id:456
+/opengui resume execution_id:456 feedback:continue
+```
+
+Slash commands は guild-scoped で登録されます。登録は
+`DISCORD_REGISTER_COMMANDS=true` の場合のみ行われます。
+
+## 検証
+
+おすすめの順序:
+
+1. Bot が返信できるか確認します:
+
+```text
+!opengui help
+```
+
+2. Bot がオンライン端末を見られるか確認します:
+
+```text
+!opengui devices
+```
+
+3. Slash command が使えるか確認します:
+
+```text
+/opengui help
+```
+
+4. 実際の端末タスクを送信します:
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+または:
+
+```text
+/opengui do task:open browser and search OpenGUI
+```
+
+期待される結果:
+
+- `help` がコマンド一覧を返します。
+- `devices` がスタンバイ中の Android 端末を表示します。
+- `do` が OpenGUI タスクを作成し、実行を開始し、進捗を同じ Discord チャンネルに投稿します。
+
+実行中、Discord には次のようなメッセージが表示されます:
+
+```text
+Created task: ...
+Starting execution: ...
+Device: ...
+Planning...
+Executing...
+```
+
+端末側でも、ブラウザを開く、検索ボックスをタップする、検索語を入力するなどの対応する操作が見えるはずです。
+
+## トラブルシューティング
+
+### Bot がオフラインのまま
+
+よくある原因:
+
+- バックエンドが起動していない。
+- `DISCORD_BOT_TOKEN` が未設定または間違っている。
+- `.env` を変更した後にバックエンドを再起動していない。
+- バックエンドプロセスが Discord に接続できない。
+
+まずバックエンドログを確認してください。`[DiscordBot] Connected as ...` がなければ、
+Bot はログインできていません。
+
+### バックエンドに `Connect Timeout Error` が出る
+
+これは通常コードの問題ではなく、ネットワークの問題です。
+
+ブラウザで Discord にアクセスできても、Node.js のバックエンドプロセスが Discord API に
+接続できるとは限りません。プロキシがブラウザだけに効いている場合があります。
+
+試すこと:
+
+- プロキシツールで global mode または TUN mode を有効にする。
+- ターミナルに `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY` を設定する。
+- ネットワーク設定を変えた後、バックエンドを再起動する。
+
+### `!opengui help` が返信しない
+
+確認すること:
+
+- Bot がオンラインか。
+- Bot が server に参加しているか。
+- channel ID が `DISCORD_ALLOWED_CHANNEL_IDS` に含まれているか。
+- user ID が `DISCORD_ALLOWED_USER_IDS` に含まれているか。
+- Bot ページで **Message Content Intent** が有効か。
+- Bot に View Channels、Send Messages、Read Message History 権限があるか。
+
+### `/opengui` が表示されない
+
+確認すること:
+
+- `.env` に `DISCORD_REGISTER_COMMANDS=true` があるか。
+- `DISCORD_CLIENT_ID` が設定されているか。
+- `DISCORD_ALLOWED_GUILD_IDS` が設定されているか。
+- Bot 招待時に `applications.commands` scope を含めたか。
+- バックエンドログに slash command 登録成功が出ているか。
+
+Slash command は表示まで数秒かかる場合があります。必要なら Discord を更新または再起動してください。
+
+### `!opengui devices` に端末が出ない
+
+Discord Bot は動いていますが、Android 端末がスタンバイ接続していません。
+
+確認すること:
+
+- 端末アプリが開いているか。
+- 端末が Mac/バックエンドのネットワークに到達できるか。
+- バックエンドログに `Device registered` があるか。
+- Web コンソールで端末がオンラインか。
+
+### 権限または allowlist の問題
+
+allowlist を設定している場合、一致する server、channel、user ID だけがタスクを実行できます。
+
+再確認してください:
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+```
+
+よくある間違い:
+
+- Application ID を server ID として使っている。
+- server ID を channel ID として使っている。
+- ID コピー前に Developer Mode を有効にしていない。
+- allowlist に入っていないチャンネルでコマンドを送っている。
+
+## 注意事項
+
+- `DISCORD_BOT_TOKEN` が空の場合、バックエンドは通常どおり起動し、Discord をスキップします。
+- Android 側に Discord 専用の変更は不要です。
+- Discord Web、Mac、Windows クライアントはすべて利用できます。Bot は特定の Discord クライアントではなく Discord API に接続します。
+- Bot が connection timeout で起動できない場合は、バックエンドプロセスが Discord にアクセスできるか確認してください。ブラウザのプロキシ設定が Node.js プロセスに適用されないことがあります。

--- a/DISCORD.md
+++ b/DISCORD.md
@@ -1,0 +1,548 @@
+<p align="center">
+  <strong>Language:</strong> <a href="./DISCORD.md">English</a> | <a href="./DISCORD.zh-CN.md">简体中文</a> | <a href="./DISCORD.ja-JP.md">日本語</a>
+</p>
+
+# Discord Remote Control
+
+Discord can be used as an optional remote command entry for OpenGUI. The bot
+receives commands in a Discord channel, the backend creates or runs OpenGUI
+tasks, and a standby Android phone executes them.
+
+Discord is only the command surface. The bot does not control the Discord app UI.
+
+```text
+Discord channel
+  -> Discord bot
+  -> OpenGUI backend
+  -> standby Android phone
+  -> result back to the same Discord channel
+```
+
+## Before You Start
+
+This feature turns a Discord channel into a remote command surface for OpenGUI.
+
+When you send:
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+the backend receives the text, creates an OpenGUI task, and dispatches it to a
+standby Android phone.
+
+This feature does not:
+
+- automate the Discord web, Mac, or Windows client UI.
+- replace the OpenGUI Android app. The Android client still performs phone actions.
+- require a Discord-specific Android APK.
+
+You need:
+
+- a Discord account.
+- a Discord server that you can manage. You can create a private test server.
+- a running local OpenGUI backend.
+- at least one Android phone connected to the backend in standby mode.
+
+## 1. Create Or Prepare A Discord Server
+
+Skip this section if you already have a test server.
+
+To create one:
+
+1. Open Discord.
+2. Click `+` in the left server list.
+3. Select **Create My Own**.
+4. Select **For me and my friends**, or the closest available option.
+5. Enter a server name, such as `opengui-test`.
+6. Open the default text channel, usually named `general`.
+
+The bot will be invited into this server and will receive commands from a text
+channel there.
+
+## 2. Create A Discord Application
+
+1. Open https://discord.com/developers/applications.
+2. Click **New Application**.
+3. Enter a name, such as `OpenGUITest`.
+4. Accept the terms and click **Create**.
+
+The application is the Discord-side project that owns the bot, client ID, and
+OAuth2 invite URL.
+
+## 3. Copy The Application ID
+
+1. In the application page, open **General Information**.
+2. Find **Application ID**.
+3. Click **Copy**.
+4. Put this value into:
+
+```env
+DISCORD_CLIENT_ID=your_application_id
+```
+
+Use **Application ID** here. Do not use Public Key, server ID, or channel ID.
+
+## 4. Create The Bot And Copy The Token
+
+1. Open **Bot** in the left sidebar.
+2. If Discord asks you to create a bot, click **Add Bot** or the equivalent button.
+3. Find the **Token** section.
+4. Click **Reset Token** or **Copy**.
+5. Discord may ask for verification.
+6. Put the copied token into:
+
+```env
+DISCORD_BOT_TOKEN=your_bot_token
+```
+
+The token is the bot password:
+
+- Do not commit it to Git.
+- Do not write it into README files.
+- Do not share it with untrusted people.
+- If it leaks, open the Bot page and click **Reset Token**.
+
+## 5. Enable Message Content Intent
+
+Still on the **Bot** page, scroll to **Privileged Gateway Intents**.
+
+Enable only:
+
+```text
+Message Content Intent
+```
+
+This allows prefix commands such as:
+
+```text
+!opengui help
+!opengui devices
+!opengui do ...
+```
+
+You do not need:
+
+```text
+Presence Intent
+Server Members Intent
+```
+
+The OpenGUI command flow does not read member lists or presence status.
+
+## 6. Generate The Invite URL
+
+1. Open **OAuth2** in the left sidebar.
+2. Open **URL Generator**.
+3. In **Scopes**, select:
+
+```text
+bot
+applications.commands
+```
+
+Both scopes are needed:
+
+- `bot` lets the bot join the server and send messages.
+- `applications.commands` enables `/opengui` slash commands.
+
+4. Scroll to **Bot Permissions**.
+5. Select:
+
+```text
+View Channels
+Send Messages
+Read Message History
+Use Slash Commands
+```
+
+Permission meaning:
+
+- View Channels: the bot can see the channel.
+- Send Messages: the bot can reply.
+- Read Message History: the bot can read message context.
+- Use Slash Commands: the bot can provide `/opengui` commands.
+
+Do not use **Administrator** as the default setup. It works for quick testing but
+grants more permission than OpenGUI needs.
+
+6. Copy the generated URL at the bottom of the page.
+7. Open it in a browser.
+8. Select your test server.
+9. Click **Authorize**.
+10. Complete the verification.
+
+When the bot appears in the server member list, the invite succeeded.
+
+The bot may be offline immediately after being invited. That is normal. It comes
+online only after the backend logs into Discord with the bot token.
+
+## 7. Enable Discord Developer Mode
+
+You need to copy server, channel, and user IDs. Discord may hide **Copy ID** by
+default.
+
+To enable it:
+
+1. Open Discord.
+2. Click the gear icon near your profile in the lower-left corner.
+3. Open **Advanced**.
+4. Enable **Developer Mode**.
+
+After this, right-click menus for servers, channels, and users should include
+**Copy ID**.
+
+## 8. Copy Server ID, Channel ID, And User ID
+
+You need three IDs for `.env`.
+
+### Server ID
+
+1. In the left server list, right-click your test server icon.
+2. Click **Copy Server ID** or **Copy ID**.
+3. Put it into:
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=your_server_id
+```
+
+Discord calls servers "guilds" in the API, so the environment variable uses
+`GUILD_IDS`.
+
+### Channel ID
+
+1. Right-click the text channel where you will send commands, such as `#general`.
+2. Click **Copy Channel ID** or **Copy ID**.
+3. Put it into:
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=your_channel_id
+```
+
+### User ID
+
+1. Find yourself in the server member list.
+2. Right-click your avatar or username.
+3. Click **Copy User ID** or **Copy ID**.
+4. Put it into:
+
+```env
+DISCORD_ALLOWED_USER_IDS=your_user_id
+```
+
+This allowlist prevents other users from triggering phone tasks.
+
+## Environment Variables
+
+Add these values to `server/apps/backend/.env`:
+
+```env
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=false
+```
+
+For the first slash-command test, set:
+
+```env
+DISCORD_REGISTER_COMMANDS=true
+```
+
+This lets the backend register `/opengui` commands in your configured guild on
+startup.
+
+After slash commands have been registered, you can set it back to:
+
+```env
+DISCORD_REGISTER_COMMANDS=false
+```
+
+Allowlist behavior:
+
+- Empty allowlist means that dimension is not restricted.
+- Non-empty allowlist means the guild, channel, or user must match.
+- For production or shared testing, set at least `DISCORD_ALLOWED_GUILD_IDS`
+  and `DISCORD_ALLOWED_CHANNEL_IDS`.
+- `DISCORD_REGISTER_COMMANDS=true` requires `DISCORD_CLIENT_ID` and
+  `DISCORD_ALLOWED_GUILD_IDS`.
+
+ID reference:
+
+| Variable | Discord source |
+|---|---|
+| `DISCORD_CLIENT_ID` | Developer Portal -> General Information -> Application ID |
+| `DISCORD_ALLOWED_GUILD_IDS` | Discord server ID |
+| `DISCORD_ALLOWED_CHANNEL_IDS` | Discord text channel ID |
+| `DISCORD_ALLOWED_USER_IDS` | Discord user ID |
+
+Local test example:
+
+```env
+DISCORD_BOT_TOKEN=your_bot_token
+DISCORD_CLIENT_ID=your_application_id
+DISCORD_ALLOWED_GUILD_IDS=your_server_id
+DISCORD_ALLOWED_CHANNEL_IDS=your_channel_id
+DISCORD_ALLOWED_USER_IDS=your_user_id
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=true
+```
+
+Multiple IDs can be comma-separated:
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=channel_id_1,channel_id_2
+DISCORD_ALLOWED_USER_IDS=user_id_1,user_id_2
+```
+
+## 9. Restart The Backend
+
+After changing `.env`, restart the backend. Environment variables are usually
+read once when the process starts.
+
+If the backend is running, press:
+
+```bash
+Ctrl + C
+```
+
+Then start it again:
+
+```bash
+cd server
+pnpm backend
+```
+
+or:
+
+```bash
+cd server
+./start.sh
+```
+
+Successful logs should include:
+
+```text
+IM channel: Discord bot registered
+[DiscordBot] Connected as OpenGUITest#3874
+```
+
+If `DISCORD_REGISTER_COMMANDS=true`, you should also see:
+
+```text
+[DiscordBot] Slash commands registered for guild 1234567890
+```
+
+If you see:
+
+```text
+Discord bot not configured, skipping
+```
+
+the backend did not read `DISCORD_BOT_TOKEN`, or `.env` is not in the expected
+place.
+
+## 10. Confirm The Android Phone Is Online
+
+Discord is only the entry point. The Android phone performs the actual actions.
+
+Before sending a task, confirm:
+
+- the OpenGUI backend is running.
+- the OpenGUI Android app is open.
+- the phone is connected to the backend.
+- backend logs include something like `Device registered`.
+
+You can also run:
+
+```text
+!opengui devices
+```
+
+If a device model appears, such as:
+
+```text
+OPPO PGEM10
+```
+
+the phone is online and waiting for tasks.
+
+## Commands
+
+Prefix commands:
+
+```text
+!opengui help
+!opengui devices
+!opengui do open browser and search OpenGUI
+!opengui run 123
+!opengui status
+!opengui status 456
+!opengui cancel 456
+!opengui pause 456
+!opengui resume 456 continue
+```
+
+Slash commands:
+
+```text
+/opengui help
+/opengui devices
+/opengui do task:open browser and search OpenGUI
+/opengui run task_id:123
+/opengui status execution_id:456
+/opengui cancel execution_id:456
+/opengui pause execution_id:456
+/opengui resume execution_id:456 feedback:continue
+```
+
+Slash commands are guild-scoped. They are registered only when
+`DISCORD_REGISTER_COMMANDS=true`.
+
+## Verification
+
+Recommended order:
+
+1. Confirm the bot can reply:
+
+```text
+!opengui help
+```
+
+2. Confirm the bot can see online phones:
+
+```text
+!opengui devices
+```
+
+3. Confirm slash commands are available:
+
+```text
+/opengui help
+```
+
+4. Dispatch a real phone task:
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+or:
+
+```text
+/opengui do task:open browser and search OpenGUI
+```
+
+Expected result:
+
+- `help` returns the command list.
+- `devices` lists the standby Android phone.
+- `do` creates an OpenGUI task, starts an execution, and posts progress back to
+  the same Discord channel.
+
+During execution, Discord should show messages like:
+
+```text
+Created task: ...
+Starting execution: ...
+Device: ...
+Planning...
+Executing...
+```
+
+The phone should perform the matching action, such as opening the browser,
+tapping the search box, and typing the query.
+
+## Troubleshooting
+
+### The Bot Stays Offline
+
+Common causes:
+
+- the backend is not running.
+- `DISCORD_BOT_TOKEN` is missing or incorrect.
+- `.env` was changed but the backend was not restarted.
+- the backend process cannot reach Discord.
+
+Check backend logs first. If there is no `[DiscordBot] Connected as ...`, the
+bot did not log in.
+
+### Backend Logs `Connect Timeout Error`
+
+This is usually a network issue, not a code issue.
+
+Browser access to Discord does not guarantee that the Node.js backend process can
+reach the Discord API. Some proxies only affect the browser.
+
+Try:
+
+- enabling global or TUN mode in your proxy tool.
+- configuring `HTTP_PROXY`, `HTTPS_PROXY`, or `ALL_PROXY` for the terminal.
+- restarting the backend after changing network settings.
+
+### `!opengui help` Does Not Reply
+
+Check:
+
+- the bot is online.
+- the bot is in the server.
+- the channel ID is included in `DISCORD_ALLOWED_CHANNEL_IDS`.
+- your user ID is included in `DISCORD_ALLOWED_USER_IDS`.
+- **Message Content Intent** is enabled on the Bot page.
+- the bot has View Channels, Send Messages, and Read Message History permissions.
+
+### `/opengui` Does Not Appear
+
+Check:
+
+- `.env` has `DISCORD_REGISTER_COMMANDS=true`.
+- `DISCORD_CLIENT_ID` is configured.
+- `DISCORD_ALLOWED_GUILD_IDS` is configured.
+- the bot invite included the `applications.commands` scope.
+- backend logs say slash command registration succeeded.
+
+Slash commands may take a few seconds to appear. Refresh Discord or restart the
+client if needed.
+
+### `!opengui devices` Shows No Phone
+
+The Discord bot works, but no Android phone is online in standby mode.
+
+Check:
+
+- the phone app is open.
+- the phone can reach the Mac/backend network.
+- backend logs include `Device registered`.
+- the web console shows the phone online.
+
+### Permission Or Allowlist Problems
+
+When allowlists are configured, only matching server, channel, and user IDs can
+trigger tasks.
+
+Recheck:
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+```
+
+Common mistakes:
+
+- using Application ID as the server ID.
+- using server ID as the channel ID.
+- not enabling Developer Mode before copying IDs.
+- sending commands in a channel that is not allowlisted.
+
+## Notes
+
+- If `DISCORD_BOT_TOKEN` is empty, the backend starts normally and skips Discord.
+- Android does not need a Discord-specific change.
+- Discord web, Mac, and Windows clients all work because the bot connects to the
+  Discord API, not to a specific client app.
+- If the bot fails with a connection timeout, check whether the backend process
+  can access Discord. Browser proxy settings may not apply to Node.js processes.

--- a/DISCORD.zh-CN.md
+++ b/DISCORD.zh-CN.md
@@ -1,0 +1,536 @@
+<p align="center">
+  <strong>语言切换：</strong><a href="./DISCORD.md">English</a> | <a href="./DISCORD.zh-CN.md">简体中文</a> | <a href="./DISCORD.ja-JP.md">日本語</a>
+</p>
+
+# Discord 远程控制
+
+Discord 可以作为 OpenGUI 的可选远程任务入口。Bot 在 Discord 频道里接收命令，
+后端创建或执行 OpenGUI 任务，再把任务下发给待命的 Android 手机执行。
+
+Discord 只是命令入口。Bot 不会直接控制 Discord 客户端界面。
+
+```text
+Discord 频道
+  -> Discord bot
+  -> OpenGUI 后端
+  -> 待命 Android 手机
+  -> 结果回传到同一个 Discord 频道
+```
+
+## 开始前需要知道
+
+这套 Discord 功能只做一件事：把 Discord 频道变成 OpenGUI 的远程命令入口。
+
+你在 Discord 里发：
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+后端会收到这句话，创建 OpenGUI 任务，然后下发给已经待命连接的 Android 手机。
+
+它不会做这些事情：
+
+- 不会自动操作 Discord 网页版、Mac 版或 Windows 版界面。
+- 不会替代 Android App，真正执行手机动作的仍然是 OpenGUI Android 客户端。
+- 不要求重新打一个专门的 Discord APK。
+
+你需要准备：
+
+- 一个 Discord 账号。
+- 一个你有管理权限的 Discord server。没有的话可以自己新建一个测试 server。
+- 本地 OpenGUI 后端能启动。
+- 至少一台 Android 手机已经能连接到 OpenGUI 后端并进入待命状态。
+
+## 1. 创建或准备 Discord Server
+
+如果你已经有自己的测试 server，可以跳过这一节。
+
+如果没有：
+
+1. 打开 Discord。
+2. 看左侧 server 列表，点击 `+`。
+3. 选择 **Create My Own**。
+4. 选择 **For me and my friends** 或类似选项。
+5. 输入一个 server 名称，例如 `opengui-test`。
+6. 创建完成后，进入默认文字频道，一般叫 `general`、`常规` 或类似名字。
+
+后面 Bot 会被邀请进这个 server，并在这个文字频道里接收命令。
+
+## 2. 创建 Discord Application
+
+1. 打开 https://discord.com/developers/applications。
+2. 点击右上角 **New Application**。
+3. 输入名字，例如 `OpenGUITest`。
+4. 勾选同意条款后点击 **Create**。
+
+这里的 application 可以理解成“Discord 机器人项目”。Bot、Client ID、OAuth2 邀请链接都从这里配置。
+
+## 3. 复制 Application ID
+
+1. 在刚创建的 application 页面里，打开左侧 **General Information**。
+2. 找到 **Application ID**。
+3. 点击旁边的 **Copy**。
+4. 这个值填到：
+
+```env
+DISCORD_CLIENT_ID=你的Application ID
+```
+
+注意：这里要的是 **Application ID**，不是 Public Key，也不是服务器 ID。
+
+## 4. 创建 Bot 并复制 Token
+
+1. 打开左侧 **Bot** 页面。
+2. 如果页面提示创建 bot，点击 **Add Bot** 或类似按钮。
+3. 找到 **Token** 区域。
+4. 点击 **Reset Token** 或 **Copy**。
+5. Discord 可能会要求你输入验证码或二次确认。
+6. 复制出来的 token 填到：
+
+```env
+DISCORD_BOT_TOKEN=你的Bot Token
+```
+
+Token 很重要，等同于机器人密码：
+
+- 不要提交到 Git。
+- 不要写进 README。
+- 不要发给不可信的人。
+- 如果泄露了，到 Bot 页面点击 **Reset Token** 换一个新的。
+
+## 5. 打开 Message Content Intent
+
+还在 **Bot** 页面，往下找到 **Privileged Gateway Intents**。
+
+只需要打开：
+
+```text
+Message Content Intent
+```
+
+它的作用是让 Bot 能读到普通文字消息内容，也就是支持：
+
+```text
+!opengui help
+!opengui devices
+!opengui do ...
+```
+
+不用打开：
+
+```text
+Presence Intent
+Server Members Intent
+```
+
+OpenGUI 的 Discord 命令链路不需要读取成员列表，也不需要读取在线状态。
+
+## 6. 生成邀请链接并邀请 Bot
+
+1. 打开左侧 **OAuth2**。
+2. 打开 **URL Generator**。
+3. 在 **Scopes** 里勾选：
+
+```text
+bot
+applications.commands
+```
+
+这两个都要选：
+
+- `bot`：让机器人加入 server，并能发消息。
+- `applications.commands`：让 `/opengui ...` 这种 Slash 命令可用。
+
+4. 往下找到 **Bot Permissions**。
+5. 勾选这些权限：
+
+```text
+View Channels
+Send Messages
+Read Message History
+Use Slash Commands
+```
+
+这些权限分别是什么意思：
+
+- View Channels：Bot 能看到频道。
+- Send Messages：Bot 能回复消息。
+- Read Message History：Bot 能读取频道历史，保证命令上下文正常。
+- Use Slash Commands：Bot 能提供 `/opengui` 命令。
+
+不建议直接选 **Administrator**。测试时虽然省事，但权限太大，不适合作为默认文档方案。
+
+6. 页面底部会生成一个 URL。
+7. 点击 **Copy**，复制这个邀请链接。
+8. 在浏览器打开这个链接。
+9. 选择你的测试 server。
+10. 点击 **Authorize**。
+11. 完成人机验证。
+
+回到 Discord server，如果右侧成员列表能看到你的 Bot，说明邀请成功。
+
+注意：刚邀请进来时 Bot 可能显示离线，这是正常的。只有后端用 token 成功连接 Discord 后，它才会在线。
+
+## 7. 打开 Discord Developer Mode
+
+后面要复制 server ID、channel ID、user ID。默认情况下 Discord 可能不显示 **Copy ID**。
+
+开启方式：
+
+1. 打开 Discord。
+2. 点击左下角自己的头像旁边的齿轮，也就是 **User Settings**。
+3. 找到 **Advanced**。
+4. 打开 **Developer Mode**。
+
+打开后，右键 server、频道、用户时，就能看到 **Copy ID**。
+
+## 8. 复制 Server ID、Channel ID、User ID
+
+你需要复制三个 ID，分别填到 `.env`。
+
+### Server ID
+
+1. 回到 Discord。
+2. 在左侧 server 列表，右键你的测试 server 图标。
+3. 点击 **Copy Server ID** 或 **Copy ID**。
+4. 填到：
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=你的Server ID
+```
+
+Discord 的 server 在 API 里叫 guild，所以这里的变量名是 `GUILD_IDS`。
+
+### Channel ID
+
+1. 右键你准备用来发命令的文字频道，例如 `#general` 或 `#常规`。
+2. 点击 **Copy Channel ID** 或 **Copy ID**。
+3. 填到：
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=你的Channel ID
+```
+
+### User ID
+
+1. 在 Discord 右侧成员列表里找到你自己。
+2. 右键你的头像或名字。
+3. 点击 **Copy User ID** 或 **Copy ID**。
+4. 填到：
+
+```env
+DISCORD_ALLOWED_USER_IDS=你的User ID
+```
+
+这个白名单可以防止其他人随便在频道里触发手机任务。
+
+## 环境变量
+
+把这些值写入 `server/apps/backend/.env`：
+
+```env
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=false
+```
+
+第一次测试 Slash 命令时，建议先设成：
+
+```env
+DISCORD_REGISTER_COMMANDS=true
+```
+
+这样后端启动时会把 `/opengui` 命令注册到你的 server。
+
+等命令已经注册成功后，可以改回：
+
+```env
+DISCORD_REGISTER_COMMANDS=false
+```
+
+这样以后每次启动后端时，就不会重复注册 Slash 命令。
+
+白名单规则：
+
+- 某个白名单为空，表示这一维度不限制。
+- 某个白名单非空，guild、channel 或 user 必须匹配。
+- 生产环境或多人测试环境，建议至少设置 `DISCORD_ALLOWED_GUILD_IDS` 和
+  `DISCORD_ALLOWED_CHANNEL_IDS`。
+- `DISCORD_REGISTER_COMMANDS=true` 需要同时配置 `DISCORD_CLIENT_ID` 和
+  `DISCORD_ALLOWED_GUILD_IDS`。
+
+ID 对照：
+
+| 变量 | Discord 来源 |
+|---|---|
+| `DISCORD_CLIENT_ID` | Developer Portal -> General Information -> Application ID |
+| `DISCORD_ALLOWED_GUILD_IDS` | Discord server ID |
+| `DISCORD_ALLOWED_CHANNEL_IDS` | Discord text channel ID |
+| `DISCORD_ALLOWED_USER_IDS` | Discord user ID |
+
+如果右键菜单里看不到 **Copy ID**，先在 Discord 打开开发者模式：
+**User Settings -> Advanced -> Developer Mode**。
+
+一个本地测试 `.env` 示例：
+
+```env
+DISCORD_BOT_TOKEN=你的Bot Token
+DISCORD_CLIENT_ID=你的Application ID
+DISCORD_ALLOWED_GUILD_IDS=你的Server ID
+DISCORD_ALLOWED_CHANNEL_IDS=你的Channel ID
+DISCORD_ALLOWED_USER_IDS=你的User ID
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=true
+```
+
+多个 ID 可以用英文逗号隔开：
+
+```env
+DISCORD_ALLOWED_CHANNEL_IDS=频道ID1,频道ID2
+DISCORD_ALLOWED_USER_IDS=用户ID1,用户ID2
+```
+
+## 9. 重启后端
+
+改完 `.env` 后，需要重启后端。`.env` 通常只会在进程启动时读取一次。
+
+如果后端正在运行，先在终端按：
+
+```bash
+Ctrl + C
+```
+
+然后重新启动后端，例如：
+
+```bash
+cd server
+pnpm backend
+```
+
+或者使用项目脚本：
+
+```bash
+cd server
+./start.sh
+```
+
+启动成功后，日志里应该看到类似：
+
+```text
+IM channel: Discord bot registered
+[DiscordBot] Connected as OpenGUITest#3874
+```
+
+如果 `DISCORD_REGISTER_COMMANDS=true`，还应该看到类似：
+
+```text
+[DiscordBot] Slash commands registered for guild 1234567890
+```
+
+如果看到：
+
+```text
+Discord bot not configured, skipping
+```
+
+说明后端没有读到 `DISCORD_BOT_TOKEN`，或者 `.env` 位置不对。
+
+## 10. 确认 Android 手机在线
+
+Discord 只是入口，真正执行动作的是 Android 手机。
+
+在发任务前，先确认：
+
+- OpenGUI 后端已经启动。
+- Android 手机上安装并打开了 OpenGUI App。
+- 手机和后端已经连上。
+- 后端日志里能看到类似 `Device registered`。
+
+你也可以先在 Discord 里运行：
+
+```text
+!opengui devices
+```
+
+如果能看到手机型号，例如：
+
+```text
+OPPO PGEM10
+```
+
+说明手机已经在线待命。
+
+## 命令
+
+前缀命令：
+
+```text
+!opengui help
+!opengui devices
+!opengui do open browser and search OpenGUI
+!opengui run 123
+!opengui status
+!opengui status 456
+!opengui cancel 456
+!opengui pause 456
+!opengui resume 456 continue
+```
+
+Slash 命令：
+
+```text
+/opengui help
+/opengui devices
+/opengui do task:open browser and search OpenGUI
+/opengui run task_id:123
+/opengui status execution_id:456
+/opengui cancel execution_id:456
+/opengui pause execution_id:456
+/opengui resume execution_id:456 feedback:continue
+```
+
+Slash 命令默认按 guild 注册，只会在 `DISCORD_REGISTER_COMMANDS=true` 时注册。
+
+## 验证
+
+建议按这个顺序测试：
+
+1. 测试 Bot 是否能回复：
+
+```text
+!opengui help
+```
+
+2. 测试 Bot 是否能看到在线手机：
+
+```text
+!opengui devices
+```
+
+3. 测试 Slash 命令是否可用：
+
+```text
+/opengui help
+```
+
+4. 测试真正下发手机任务：
+
+```text
+!opengui do open browser and search OpenGUI
+```
+
+或者使用 Slash 命令：
+
+```text
+/opengui do task:open browser and search OpenGUI
+```
+
+预期结果：
+
+- `help` 返回命令列表。
+- `devices` 列出在线待命 Android 手机。
+- `do` 创建 OpenGUI 任务、启动执行，并把执行进度回传到同一个 Discord 频道。
+
+任务开始后，Discord 里会看到类似：
+
+```text
+Created task: ...
+Starting execution: ...
+Device: ...
+Planning...
+Executing...
+```
+
+手机上也应该能看到对应操作，例如打开浏览器、点击搜索框、输入关键词。
+
+## 常见问题
+
+### Bot 一直离线
+
+常见原因：
+
+- 后端没有启动。
+- `.env` 里的 `DISCORD_BOT_TOKEN` 没填或填错。
+- 修改 `.env` 后没有重启后端。
+- 终端里的后端进程连不上 Discord。
+
+先看后端日志。如果没有 `[DiscordBot] Connected as ...`，说明 Bot 没有成功登录。
+
+### 后端提示 Connect Timeout Error
+
+这通常不是代码问题，而是网络问题。
+
+很多代理只代理浏览器，不代理终端里的 Node.js 后端进程。Discord 网页能打开，不代表后端一定能连上 Discord API。
+
+解决方式：
+
+- 打开代理软件的全局模式或 TUN 模式。
+- 或者给终端配置 `HTTP_PROXY`、`HTTPS_PROXY`、`ALL_PROXY`。
+- 配好后重启后端。
+
+### `!opengui help` 没反应
+
+检查这些点：
+
+- Bot 是否在线。
+- Bot 是否在这个 server 里。
+- 你发命令的频道 ID 是否在 `DISCORD_ALLOWED_CHANNEL_IDS` 白名单里。
+- 你的用户 ID 是否在 `DISCORD_ALLOWED_USER_IDS` 白名单里。
+- Bot 页面是否打开了 **Message Content Intent**。
+- Bot 是否有 View Channel、Send Messages、Read Message History 权限。
+
+### `/opengui` 没出现
+
+检查这些点：
+
+- `.env` 里是否设置了 `DISCORD_REGISTER_COMMANDS=true`。
+- 是否配置了 `DISCORD_CLIENT_ID`。
+- 是否配置了 `DISCORD_ALLOWED_GUILD_IDS`。
+- Bot 邀请时是否选择了 `applications.commands` scope。
+- 后端启动日志里是否出现了 slash command 注册成功信息。
+
+Slash 命令有时需要等几秒才显示，也可以重启 Discord 客户端或刷新网页。
+
+### `!opengui devices` 看不到手机
+
+说明 Discord Bot 通了，但 Android 手机没有在线待命。
+
+检查：
+
+- 手机 App 是否打开。
+- 手机是否和 Mac/后端在同一网络，或者之前的无线连接是否还有效。
+- 后端日志里是否出现 `Device registered`。
+- Web 控制台里是否能看到手机在线。
+
+### 提示没有权限或没有反应
+
+如果配置了白名单，只有匹配的 server、channel、user 才能触发任务。
+
+重新复制并检查：
+
+```env
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+```
+
+最常见的小白错误是：
+
+- 把 Application ID 填成了 Server ID。
+- 把 Channel ID 填成了 Server ID。
+- 复制 ID 时没有打开 Developer Mode。
+- 在一个没有加入白名单的频道里发命令。
+
+## 注意事项
+
+- `DISCORD_BOT_TOKEN` 为空时，后端会正常启动并跳过 Discord。
+- Android APK 不需要因为 Discord 功能做专门修改。
+- Discord 网页版、Mac 版、Windows 版都可用，因为 Bot 连接的是 Discord API，
+  不是某个具体 Discord 客户端。
+- 如果 Bot 启动时报连接超时，检查后端进程是否能访问 Discord。浏览器代理不一定
+  会自动作用到 Node.js 后端进程。

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <strong>Language:</strong> <a href="./README.md">English</a> | <a href="./README.zh-CN.md">简体中文</a> | <a href="./README.ja-JP.md">日本語</a>
+  <strong>言語:</strong> <a href="./README.md">English</a> | <a href="./README.zh-CN.md">简体中文</a> | <a href="./README.ja-JP.md">日本語</a>
 </p>
 
 <p align="center">
@@ -14,17 +14,11 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="手動セットアップドキュメント"></a>
 </p>
 
-<p align="center">
-  OpenGUI が実機 Android エージェントの構築やテストに役立った場合は、<a href="https://github.com/Core-Mate/open-gui">GitHub Star でプロジェクトの成長を応援してください</a>。
-</p>
+## 最近の更新
 
-## 📣 最近の更新
-
-- `[2026.5.7]` README、バックエンド起動出力、Android 設定画面、初回タスク成功後の軽い案内に GitHub Star への導線を追加しました。
+- `[2026.5.9]` Discord IM エントリーを追加しました。プレフィックスコマンド、スラッシュコマンド、allowlist、guild 単位のコマンド登録に対応し、Discord チャンネルから Android タスクをリモート実行できます。
 - `[2026.5.7]` Docker ベースのバックエンド起動時に、一般的な PostgreSQL / Redis ポート競合を避けられるようローカル起動フローを強化しました。
-- `[2026.5.2]` ソース公開版として読みやすくするため、公開コードコメントと開発者向け文言を英語化しました。
 - `[2026.5.1]` バックエンドのオンボーディングとして、`.env.example`、起動時チェック、graph agent 向け VLM 環境変数設定を整備しました。
-- `[2026.4.30]` 日本語 README を追加し、ライセンスを BUSL-1.1 に切り替え、公開 Android UI とプロンプトを英語化しました。
 
 ## OpenGUI でできること
 
@@ -35,13 +29,13 @@ OpenGUI は、AI が実際の Android スマートフォンを操作できるよ
 - **主要な Android アプリを操作**: X、Reddit、Hacker News、Telegram、WeChat、Weibo、小紅書などの Android アプリ上で、AI にモバイルタスクを実行させることができます。
 - **組み込みワークフローを実行**: バックエンド、Android クライアント、スタンバイディスパッチパス、組み込みタスク機能一式がすぐに実行可能な状態で含まれています。
 - **Claude や Codex にブートストラップさせる**: [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) をモデルに指示し、目的を自然言語で説明すれば、セットアップ、ビルド、インストール、ローカルデバッグをモデルが処理します。
-- **リモートワーカーとしてスマートフォンを操作**: Feishu、Telegram、REST API 経由でタスクをディスパッチし、デバイスをスタンバイ状態に保ち、バックエンドから構造化された結果を受け取ることができます。
+- **リモートワーカーとしてスマートフォンを操作**: Feishu、Telegram、Discord、REST API 経由でタスクをディスパッチし、デバイスをスタンバイ状態に保ち、バックエンドから構造化された結果を受け取ることができます。
 
 ## 特徴
 
 - **長時間タスク向けに設計**: OpenGUI は、数時間に及ぶモバイルワークフローに対応しており、進捗、レビュー、リカバリーをシステム内で管理します。
 - **タスクの継続実行**: `Plan Supervisor` がタスクの状態と継続を管理し、`Executor Graph` がスクリーンショット、ビジョン、アクション、ユーザー呼び出しのループをデバイスのリアルタイム状態上で実行し、`Summarizer` が構造化された結果で実行を完了します。
-- **スタンバイ待機**: スタンバイディスパッチパスにより、Feishu、Telegram、REST エントリーポイントを通じてデバイスがリモートワークを受信できます。
+- **スタンバイ待機**: スタンバイディスパッチパスにより、Feishu、Telegram、Discord、REST エントリーポイントを通じてデバイスがリモートワークを受信できます。
 - **ロール別のモデル割り当て**: モデルルーティングにより、プランニングと VLM 実行を分離し、チームがジョブごとにプロバイダーを選択できます。
 - **実際のモバイルワークフローに基づいた設計**: グラフ、デバイス実行パス、モデル分割がソースツリーに組み込まれています。
 
@@ -63,13 +57,13 @@ OpenGUI は、明示的なオーケストレーションレイヤーを持つモ
 | **タスク状態** | 通常ローカルでセッション単位 | バックエンドグラフでタスク状態を管理 |
 | **デバイスパス** | 多くの場合ノートPC主導の制御 | スタンバイ・実行ソケット付きの Android クライアント |
 | **モデル使用** | 1つのモデルがほぼ全てを処理 | プランニングと VLM パスをプロバイダー間で分割可能 |
-| **リモート操作** | オプションのアドオン | Feishu、Telegram、REST API、スタンバイディスパッチがバックエンドに組み込み済み |
+| **リモート操作** | オプションのアドオン | Feishu、Telegram、Discord、REST API、スタンバイディスパッチがバックエンドに組み込み済み |
 
 ## 代表的なユースケース
 
 - X を開いてトピックに関する最近の投稿を収集する
 - 実機で Reddit や Hacker News のスレッドを読んで要約する
-- Feishu や Telegram から Android タスクをリモートでトリガーする
+- Feishu、Telegram、Discord、REST API から Android タスクをリモートでトリガーする
 - Android デバイス上で反復的なモバイルワークフローを実行する
 - 状態管理、レビュー、リカバリーが必要な長時間モバイルワークフローを実行する
 
@@ -153,7 +147,20 @@ cd client
 - [server/start.sh](./server/start.sh)
 - [client/start.sh](./client/start.sh)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.ja-JP.md](./DISCORD.ja-JP.md)
 - [client/README.md](./client/README.md)
+
+### 3. 任意の Discord リモートコントロール
+
+Discord は任意の IM チャンネルとして有効化できます。Discord Bot が
+`!opengui devices` や `!opengui do ...` などのコマンドを受け取り、バックエンドが
+スタンバイ中の Android 端末へタスクをディスパッチし、進捗を同じチャンネルに
+投稿します。
+
+ローカル利用には必須ではありません。`DISCORD_BOT_TOKEN` が空の場合、バックエンド
+は通常どおり起動し、Discord をスキップします。
+
+詳細な設定手順: [DISCORD.ja-JP.md](./DISCORD.ja-JP.md)。
 
 ## システム構成
 
@@ -171,7 +178,7 @@ flowchart LR
     SP --> SM["サマライザー"]
     SM --> SR["構造化された結果"]
 
-    RD["Feishu / Telegram / REST API"] --> ST["スタンバイゲートウェイ"]
+    RD["Feishu / Telegram / Discord / REST API"] --> ST["スタンバイゲートウェイ"]
     ST --> AC
 
     SP --> MR["モデルルーティング"]
@@ -184,6 +191,7 @@ flowchart LR
 - **バックエンドグラフ**: `server/apps/backend/src/modules/graph-agent/graph/`
 - **タスク API**: `server/apps/backend/src/modules/task/task.controller.ts`
 - **スタンバイディスパッチ**: `server/apps/backend/src/common/ws/standby.gateway.ts`
+- **IM チャンネルディスパッチ**: `server/apps/backend/src/modules/im-channel/`
 - **Android スタンバイ接続**: `client/core_network/src/main/java/com/coremate/opengui/network/websocket/StandbySocketManager.kt`
 - **Android 実行パス**: `client/core_accessibility/src/main/java/com/coremate/opengui/accessibility/GestureService.kt`
 
@@ -192,6 +200,7 @@ flowchart LR
 - [skills/open-gui-bootstrap/SKILL.md](./skills/open-gui-bootstrap/SKILL.md)
 - [docs/get-started.md](./docs/get-started.md)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.ja-JP.md](./DISCORD.ja-JP.md)
 - [client/README.md](./client/README.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [SECURITY.md](./SECURITY.md)
@@ -199,13 +208,11 @@ flowchart LR
 
 ## コミュニティ / サポート
 
-OpenGUI が役に立った場合、以下の方法でサポートいただけると助かります:
+特に有用なプロジェクトフィードバック:
 
-- リポジトリにスターを付ける
 - バグや機能リクエストの Issue を作成する
 - 実際のユースケースやデプロイメントのフィードバックを共有する
 - ドキュメント、インテグレーション、修正のコントリビューション
-- モバイル AI エージェントを構築しているチームにプロジェクトを紹介する
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,11 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="Manual setup docs"></a>
 </p>
 
-<p align="center">
-  If OpenGUI helps you build or test real Android agents, <a href="https://github.com/Core-Mate/open-gui">a GitHub star helps the project grow</a>.
-</p>
+## Recent Updates
 
-## 📣 News
-
-- `[2026.5.7]` OpenGUI added GitHub Star CTA touchpoints across the README, backend startup output, Android settings, and the first successful phone task prompt.
-- `[2026.5.7]` Local startup was hardened to avoid common PostgreSQL and Redis port conflicts during Docker-based backend setup.
-- `[2026.5.2]` Public code comments and developer-facing copy were translated to English for a cleaner source-available release.
-- `[2026.5.1]` Backend onboarding was improved with a completed `.env.example`, clearer startup checks, and graph-agent VLM environment configuration.
-- `[2026.4.30]` OpenGUI added a Japanese README and switched the project license to BUSL-1.1 while translating public Android UI and prompts to English.
+- `[2026.5.9]` Added a Discord IM channel for remote Android task dispatch, including prefix commands, slash commands, allowlists, and guild-scoped command registration.
+- `[2026.5.7]` Hardened local startup to avoid common PostgreSQL and Redis port conflicts during Docker-based backend setup.
+- `[2026.5.1]` Improved backend onboarding with `.env.example`, startup checks, and graph-agent VLM environment configuration.
 
 ## What You Can Do with OpenGUI
 
@@ -35,13 +29,13 @@ You can use the same repository in four practical ways:
 - **Operate mainstream Android apps**: let AI handle mobile tasks inside X, Reddit, Hacker News, Telegram, WeChat, Weibo, Xiaohongshu, and other Android apps on a real phone.
 - **Run shipped workflows**: the repository already includes a runnable backend, Android client, standby dispatch path, and a set of built-in task capabilities.
 - **Let Claude or Codex bootstrap it for you**: point the model at [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md), describe the goal in plain language, and let it handle setup, build, install, and local debugging.
-- **Operate phones as remote workers**: dispatch tasks through Feishu, Telegram, or REST API, keep devices on standby, and get structured results back from the backend.
+- **Operate phones as remote workers**: dispatch tasks through Feishu, Telegram, Discord, or REST API, keep devices on standby, and get structured results back from the backend.
 
 ## Highlights
 
 - **Built for long-running tasks**: OpenGUI is shaped for mobile workflows that may run for hours, with progress, review, and recovery kept inside the system.
 - **The task can keep moving**: `Plan Supervisor` maintains task state and continuation, `Executor Graph` runs screenshot, vision, action, and call-user loops on top of live device state, and `Summarizer` closes the run with a structured result.
-- **Phones can stay on standby**: the standby dispatch path lets devices receive remote work through Feishu, Telegram, or REST entry points.
+- **Phones can stay on standby**: the standby dispatch path lets devices receive remote work through Feishu, Telegram, Discord, or REST entry points.
 - **Models can be assigned by role**: model routing separates planning from VLM execution so teams can choose providers by job.
 - **The system is organized around real mobile workflows**: the graph, device execution path, and model split already exist in the source tree.
 
@@ -63,13 +57,13 @@ The source code currently exposes these pieces:
 | **Task state** | Usually local and session-bound | Task state managed in the backend graph |
 | **Device path** | Often laptop-driven control | Android client with standby and execution sockets |
 | **Model usage** | One model does most of the work | Planning and VLM paths can be split across providers |
-| **Remote operation** | Optional add-on | Feishu, Telegram, REST API, and standby dispatch are built into the backend |
+| **Remote operation** | Optional add-on | Feishu, Telegram, Discord, REST API, and standby dispatch are built into the backend |
 
 ## Typical Use Cases
 
 - Open X and collect recent posts for a topic
 - Read and summarize Reddit or Hacker News threads on a live phone
-- Trigger Android tasks remotely from Feishu or Telegram
+- Trigger Android tasks remotely from Feishu, Telegram, Discord, or REST API
 - Execute repetitive mobile workflows on Android devices
 - Run long mobile workflows that need state, review, and recovery over many hours
 
@@ -153,7 +147,19 @@ Reference docs:
 - [server/start.sh](./server/start.sh)
 - [client/start.sh](./client/start.sh)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.md](./DISCORD.md)
 - [client/README.md](./client/README.md)
+
+### 3. Optional Discord remote control
+
+Discord can be enabled as an optional IM channel. A Discord bot receives commands
+such as `!opengui devices` or `!opengui do ...`, then the backend dispatches the
+task to a standby Android phone and posts progress back to the same channel.
+
+This is not required for local use. If `DISCORD_BOT_TOKEN` is empty, the backend
+starts normally and skips Discord.
+
+Full setup guide: [DISCORD.md](./DISCORD.md).
 
 ## The System
 
@@ -171,7 +177,7 @@ flowchart LR
     SP --> SM["Summarizer"]
     SM --> SR["Structured Results"]
 
-    RD["Feishu / Telegram / REST API"] --> ST["Standby Gateway"]
+    RD["Feishu / Telegram / Discord / REST API"] --> ST["Standby Gateway"]
     ST --> AC
 
     SP --> MR["Model Routing"]
@@ -184,6 +190,7 @@ flowchart LR
 - **Backend graph**: `server/apps/backend/src/modules/graph-agent/graph/`
 - **Task APIs**: `server/apps/backend/src/modules/task/task.controller.ts`
 - **Standby dispatch**: `server/apps/backend/src/common/ws/standby.gateway.ts`
+- **IM channel dispatch**: `server/apps/backend/src/modules/im-channel/`
 - **Android standby connection**: `client/core_network/src/main/java/com/coremate/opengui/network/websocket/StandbySocketManager.kt`
 - **Android execution path**: `client/core_accessibility/src/main/java/com/coremate/opengui/accessibility/GestureService.kt`
 
@@ -192,6 +199,7 @@ flowchart LR
 - [skills/open-gui-bootstrap/SKILL.md](./skills/open-gui-bootstrap/SKILL.md)
 - [docs/get-started.md](./docs/get-started.md)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.md](./DISCORD.md)
 - [client/README.md](./client/README.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [SECURITY.md](./SECURITY.md)
@@ -199,13 +207,11 @@ flowchart LR
 
 ## Community / Support
 
-If OpenGUI is useful to you, the most helpful ways to support it are:
+The most useful project feedback is:
 
-- star the repository
 - open issues for bugs and feature requests
 - share real use cases and deployment feedback
 - contribute docs, integrations, and fixes
-- introduce the project to teams building mobile AI agents
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,17 +14,11 @@
   <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="Manual setup docs"></a>
 </p>
 
-<p align="center">
-  如果 OpenGUI 帮你构建或测试真实 Android Agent，<a href="https://github.com/Core-Mate/open-gui">给项目一个 GitHub Star 会帮助它继续成长</a>。
-</p>
+## 近期更新
 
-## 📣 近期更新
-
-- `[2026.5.7]` OpenGUI 在 README、后端启动输出、Android 设置页和首次成功执行任务后的轻提示中加入 GitHub Star 入口。
+- `[2026.5.9]` 新增 Discord IM 入口，支持前缀命令、Slash 命令、安全白名单和 guild-scoped 命令注册，可从 Discord 频道远程下发 Android 任务。
 - `[2026.5.7]` 本地启动流程增强，Docker 方式启动后端时会避开常见的 PostgreSQL 和 Redis 端口冲突。
-- `[2026.5.2]` 公开代码注释和面向开发者的文案完成英文化，便于源码可见版本对外发布。
 - `[2026.5.1]` 后端上手流程补齐 `.env.example`、启动检查提示和 graph agent 的 VLM 环境变量配置。
-- `[2026.4.30]` OpenGUI 新增日文 README，并将项目许可证切换到 BUSL-1.1，同时把公开 Android UI 和 Prompt 翻译为英文。
 
 ## 你可以用 OpenGUI 做什么
 
@@ -35,13 +29,13 @@ OpenGUI 让 AI 操作真实的 Android 手机。
 - **操作主流 Android App**：让 AI 在真实手机上执行 X、Reddit、Hacker News、Telegram、微信、微博、小红书等移动任务。
 - **运行现成工作流**：仓库已经包含可直接启动的后端、Android 客户端、待命派发链路，以及部分预置任务能力。
 - **让 Claude 或 Codex 帮你跑起来**：把 [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) 交给模型，直接用自然语言描述目标，让它处理安装、构建、安装 APK 和本地排障。
-- **把手机当成远程 worker 使用**：通过飞书、Telegram 或 REST API 下发任务，让设备保持待命，并从后端拿回结构化结果。
+- **把手机当成远程 worker 使用**：通过飞书、Telegram、Discord 或 REST API 下发任务，让设备保持待命，并从后端拿回结构化结果。
 
 ## 亮点
 
 - **适合长时任务**：OpenGUI 面向长时移动工作流，任务可以持续运行数小时，并在过程中继续推进、复核和恢复。
 - **任务能持续跑下去**：`Plan Supervisor` 维护任务列表和继续执行状态，`Executor Graph` 围绕当前设备状态运行截图、视觉分析、动作执行和 call-user 循环，`Summarizer` 在任务结束时输出结构化结果。
-- **手机可以保持待命**：待命派发链路让设备可以通过飞书、Telegram 或 REST 入口接收远程任务。
+- **手机可以保持待命**：待命派发链路让设备可以通过飞书、Telegram、Discord 或 REST 入口接收远程任务。
 - **模型可以按角色分工**：模型路由把规划侧和 VLM 执行侧拆开，便于按角色选择 provider。
 - **整套系统围绕真实移动工作流组织**：graph、设备执行链路和模型分工已经在源码里落地。
 
@@ -63,13 +57,13 @@ OpenGUI 采用的是一套分层清晰的移动 operator system。
 | **任务状态** | 常常停留在本地会话里 | 任务状态由后端 graph 持有 |
 | **设备链路** | 常见是电脑侧驱动手机 | Android 客户端自带待命与执行连接 |
 | **模型使用** | 一个主模型承担大部分工作 | 规划和 VLM 执行可以拆给不同 provider |
-| **远程运行** | 往往是附加能力 | 飞书、Telegram、REST API、待命派发已经在后端里 |
+| **远程运行** | 往往是附加能力 | 飞书、Telegram、Discord、REST API、待命派发已经在后端里 |
 
 ## 典型使用场景
 
 - 打开 X 并采集某个主题的近期内容
 - 在真实手机上阅读并总结 Reddit 或 Hacker News 帖子
-- 从飞书或 Telegram 远程触发手机任务
+- 从飞书、Telegram、Discord 或 REST API 远程触发手机任务
 - 在 Android 设备上执行重复性的移动工作流
 - 运行需要状态管理、复核和恢复机制的长时移动工作流
 
@@ -153,7 +147,19 @@ cd client
 - [server/start.sh](./server/start.sh)
 - [client/start.sh](./client/start.sh)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.zh-CN.md](./DISCORD.zh-CN.md)
 - [client/README.md](./client/README.md)
+
+### 3. 可选的 Discord 远程控制
+
+Discord 可以作为可选 IM 入口启用。Discord Bot 接收 `!opengui devices` 或
+`!opengui do ...` 这类命令，后端再把任务下发给待命 Android 手机，并把进度回传到
+同一个 Discord 频道。
+
+这不是本地运行的必选项。`DISCORD_BOT_TOKEN` 为空时，后端会正常启动并跳过
+Discord。
+
+完整配置说明见：[DISCORD.zh-CN.md](./DISCORD.zh-CN.md)。
 
 ## 系统结构
 
@@ -171,7 +177,7 @@ flowchart LR
     SP --> SM["Summarizer"]
     SM --> SR["结构化结果"]
 
-    RD["Feishu / Telegram / REST API"] --> ST["Standby Gateway"]
+    RD["Feishu / Telegram / Discord / REST API"] --> ST["Standby Gateway"]
     ST --> AC
 
     SP --> MR["Model Routing"]
@@ -184,30 +190,30 @@ flowchart LR
 - **后端 graph**：`server/apps/backend/src/modules/graph-agent/graph/`
 - **任务 API**：`server/apps/backend/src/modules/task/task.controller.ts`
 - **待命派发**：`server/apps/backend/src/common/ws/standby.gateway.ts`
+- **IM 入口派发**：`server/apps/backend/src/modules/im-channel/`
 - **设备待命连接**：`client/core_network/src/main/java/com/coremate/opengui/network/websocket/StandbySocketManager.kt`
 - **Android 执行链路**：`client/core_accessibility/src/main/java/com/coremate/opengui/accessibility/GestureService.kt`
 
-## Documentation
+## 文档
 
 - [skills/open-gui-bootstrap/SKILL.md](./skills/open-gui-bootstrap/SKILL.md)
 - [docs/get-started.md](./docs/get-started.md)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
+- [DISCORD.zh-CN.md](./DISCORD.zh-CN.md)
 - [client/README.md](./client/README.md)
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [SECURITY.md](./SECURITY.md)
 - [CLAUDE.md](./CLAUDE.md)
 
-## Community / Support
+## 社区 / 支持
 
-如果 OpenGUI 对你有帮助，最有效的支持方式包括：
+最有价值的项目反馈包括：
 
-- 给仓库点 Star
 - 提交 bug 和 feature request
 - 分享真实使用场景和部署反馈
 - 贡献文档、集成和修复
-- 推荐给正在做移动 AI Agent 的团队
 
-## License
+## 许可证
 
 OpenGUI 采用 Business Source License 1.1 (BUSL-1.1)，源码可见。
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -40,8 +40,24 @@ What `server/start.sh` does:
 
 Required keys for a practical first run:
 
-- `CLAUDE_API_KEY`
 - `VLM_API_KEY`
+- `VLM_BASE_URL`
+- `VLM_MODEL`
+
+The backend currently uses the `VLM_*` variables as the shared
+OpenAI-compatible model configuration for graph agents. They are used by
+planning, supervision, summarization, and the executor vision path.
+
+Example:
+
+```env
+VLM_API_KEY=your_api_key
+VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+VLM_MODEL=qwen3.6-plus
+```
+
+The backend can start without these values, but real task execution will fail
+when the graph needs to call the model.
 
 Useful endpoints after startup:
 
@@ -82,4 +98,5 @@ For local runs, the backend task controllers also default to `userId = 1`, so fi
 ## More detail
 
 - Backend details: [`server/apps/backend/README.md`](../server/apps/backend/README.md)
+- Discord remote control: [`DISCORD.md`](../DISCORD.md)
 - Android client details: [`client/README.md`](../client/README.md)

--- a/server/apps/backend/.env.example
+++ b/server/apps/backend/.env.example
@@ -14,7 +14,10 @@ REDIS_PORT=56379
 REDIS_DB=0
 REDIS_PASSWORD=
 
-# AI model config (used by all graph agents)
+# Graph agent model config (OpenAI-compatible)
+# Used by planner, supervisor, summarizer, and executor VLM calls.
+# VLM_API_KEY is required before tasks can execute successfully.
+# VLM_BASE_URL can point to any OpenAI-compatible endpoint.
 VLM_API_KEY=
 VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 VLM_MODEL=qwen3.6-plus
@@ -39,3 +42,21 @@ VLM_MODEL=qwen3.6-plus
 # Telegram Bot — long polling mode, no public IP needed
 # 1. Message @BotFather on Telegram → /newbot → get token
 # TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+
+# Discord Bot — Gateway mode, no public IP needed.
+# Leave DISCORD_BOT_TOKEN empty to disable Discord without affecting backend startup.
+# 1. Create an application at https://discord.com/developers/applications
+# 2. Copy Application ID into DISCORD_CLIENT_ID
+# 3. Add a Bot and copy the bot token into DISCORD_BOT_TOKEN
+# 4. Enable Message Content Intent if you want to use prefix commands
+# 5. Invite the bot with scopes: bot, applications.commands
+# 6. Required permissions: View Channel, Send Messages, Read Message History, Use Slash Commands
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+# Comma-separated allowlists. Keep empty only for local development.
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+DISCORD_COMMAND_PREFIX=!opengui
+# Set true when creating/updating slash commands for a test guild.
+DISCORD_REGISTER_COMMANDS=false

--- a/server/apps/backend/README.md
+++ b/server/apps/backend/README.md
@@ -28,6 +28,73 @@ pnpm build
 pnpm start:prod
 ```
 
+## 配置与远程任务入口
+
+后端配置文件使用 `server/apps/backend/.env`。第一次启动前可以从示例文件复制：
+
+```bash
+cp .env.example .env
+```
+
+基础运行至少需要 PostgreSQL、Redis 和模型配置。未配置 IM 机器人时，后端会正常启动，只跳过对应入口。
+
+### Graph Agent 模型配置
+
+OpenGUI 后端的 graph agents 使用 OpenAI-compatible 的模型接口。当前统一通过 `.env` 里的 `VLM_*` 变量配置：
+
+```env
+VLM_API_KEY=
+VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+VLM_MODEL=qwen3.6-plus
+```
+
+这组配置会被规划、监督、总结和 executor VLM 路径共用。也就是说，变量名虽然叫 `VLM_*`，但它不只影响视觉执行节点，也会影响 graph agent 的文本侧模型调用。
+
+说明：
+
+- `VLM_API_KEY`：模型服务 API key，执行真实任务前必须配置。
+- `VLM_BASE_URL`：OpenAI-compatible endpoint。使用 OpenAI 默认接口时可以按实际 provider 配置。
+- `VLM_MODEL`：模型名，例如 `qwen3.6-plus` 或你的 provider 支持的其他模型。
+- 后端可以在缺少这些值时启动，但任务执行到模型调用时会失败。
+
+### Discord 入口
+
+Discord Bot 可以作为远程任务入口：用户在 Discord 频道里发送命令，后端创建或执行 OpenGUI 任务，再把任务下发给已经待命的 Android 手机。
+
+支持两种命令形式：
+
+```text
+!opengui help
+!opengui devices
+!opengui do open browser and search OpenGUI
+```
+
+```text
+/opengui help
+/opengui devices
+/opengui do task:open browser and search OpenGUI
+```
+
+需要在 `.env` 中配置：
+
+```env
+DISCORD_BOT_TOKEN=
+DISCORD_CLIENT_ID=
+DISCORD_ALLOWED_GUILD_IDS=
+DISCORD_ALLOWED_CHANNEL_IDS=
+DISCORD_ALLOWED_USER_IDS=
+DISCORD_COMMAND_PREFIX=!opengui
+DISCORD_REGISTER_COMMANDS=false
+```
+
+安全建议：
+
+- 生产或团队测试环境建议至少配置 `DISCORD_ALLOWED_GUILD_IDS` 和 `DISCORD_ALLOWED_CHANNEL_IDS`。
+- 前缀命令需要在 Discord Developer Portal 打开 **Message Content Intent**。
+- Slash 命令建议保持 guild-scoped 注册，并只在需要更新命令时设置 `DISCORD_REGISTER_COMMANDS=true`。
+
+完整配置步骤见 [../../../DISCORD.zh-CN.md](../../../DISCORD.zh-CN.md)。
+
 ---
 
 ## Agent Graph 架构

--- a/server/apps/backend/package.json
+++ b/server/apps/backend/package.json
@@ -66,6 +66,7 @@
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.14.2",
 		"deepagents": "^1.3.1",
+		"discord.js": "^14.26.3",
 		"dotenv": "^16.4.7",
 		"express": "^5.1.0",
 		"ioredis": "^5.7.0",

--- a/server/apps/backend/src/app.module.ts
+++ b/server/apps/backend/src/app.module.ts
@@ -83,7 +83,7 @@ import { PrismaModule } from "./prisma/prisma.module";
 		// Creator Agent module (Claude Agent SDK based content creation)
 		CreatorAgentModule,
 
-		// IM Channel module (remote task dispatch via Feishu/Telegram)
+		// IM Channel module (remote task dispatch via Feishu/Telegram/Discord)
 		ImChannelModule,
 	],
 	controllers: [AppController],

--- a/server/apps/backend/src/modules/im-channel/command/command-parser.service.spec.ts
+++ b/server/apps/backend/src/modules/im-channel/command/command-parser.service.spec.ts
@@ -1,0 +1,77 @@
+import { CommandParserService } from "./command-parser.service";
+import { CommandType } from "./command.types";
+
+describe("CommandParserService", () => {
+	let parser: CommandParserService;
+
+	beforeEach(() => {
+		parser = new CommandParserService();
+	});
+
+	it("parses Discord prefix help command", () => {
+		expect(parser.parse("!opengui help")).toMatchObject({
+			type: CommandType.HELP,
+		});
+	});
+
+	it("parses Discord prefix do command", () => {
+		expect(
+			parser.parse("!opengui do open browser and search OpenGUI"),
+		).toMatchObject({
+			type: CommandType.DO_TASK,
+			description: "open browser and search OpenGUI",
+		});
+	});
+
+	it("parses Discord prefix run command", () => {
+		expect(parser.parse("!opengui run 123")).toMatchObject({
+			type: CommandType.RUN_TASK,
+			taskId: 123,
+		});
+	});
+
+	it("parses execution id for status, cancel, and pause commands", () => {
+		expect(parser.parse("!opengui status 456")).toMatchObject({
+			type: CommandType.STATUS,
+			executionId: 456,
+		});
+		expect(parser.parse("/cancel 456")).toMatchObject({
+			type: CommandType.CANCEL,
+			executionId: 456,
+		});
+		expect(parser.parse("/pause 456")).toMatchObject({
+			type: CommandType.PAUSE,
+			executionId: 456,
+		});
+	});
+
+	it("parses resume command with execution id and feedback", () => {
+		expect(parser.parse("!opengui resume 456 continue now")).toMatchObject({
+			type: CommandType.RESUME,
+			executionId: 456,
+			feedback: "continue now",
+		});
+	});
+
+	it("keeps existing slash commands working", () => {
+		expect(parser.parse("/do test task")).toMatchObject({
+			type: CommandType.DO_TASK,
+			description: "test task",
+		});
+		expect(parser.parse("/run 7")).toMatchObject({
+			type: CommandType.RUN_TASK,
+			taskId: 7,
+		});
+	});
+
+	it("keeps existing Chinese commands working", () => {
+		expect(parser.parse("做：打开浏览器")).toMatchObject({
+			type: CommandType.DO_TASK,
+			description: "打开浏览器",
+		});
+		expect(parser.parse("执行：8")).toMatchObject({
+			type: CommandType.RUN_TASK,
+			taskId: 8,
+		});
+	});
+});

--- a/server/apps/backend/src/modules/im-channel/command/command-parser.service.ts
+++ b/server/apps/backend/src/modules/im-channel/command/command-parser.service.ts
@@ -6,67 +6,102 @@ import { CommandType, type ParsedCommand } from "./command.types";
  */
 @Injectable()
 export class CommandParserService {
-	parse(text: string): ParsedCommand {
-		const trimmed = text.trim();
+	parse(text: string, options?: { commandPrefix?: string }): ParsedCommand {
+		const rawText = text.trim();
+		const trimmed = this.stripCommandPrefix(
+			rawText,
+			options?.commandPrefix ?? "!opengui",
+		);
 
 		// /tasks
-		if (/^\/tasks?\b/i.test(trimmed)) {
-			return { type: CommandType.LIST_TASKS, rawText: trimmed };
+		if (/^\/?(?:tasks?|list)\b/i.test(trimmed)) {
+			return { type: CommandType.LIST_TASKS, rawText };
 		}
 
 		// /run <ID>
-		const runMatch = trimmed.match(/^\/run\s+(\d+)/i);
+		const runMatch = trimmed.match(/^\/?run\s+(\d+)/i);
 		if (runMatch) {
 			return {
 				type: CommandType.RUN_TASK,
 				taskId: Number.parseInt(runMatch[1], 10),
-				rawText: trimmed,
+				rawText,
 			};
 		}
 
 		// /do <description>
-		const doMatch = trimmed.match(/^\/do\s+(.+)/is);
+		const doMatch = trimmed.match(/^\/?do\s+(.+)/is);
 		if (doMatch) {
 			return {
 				type: CommandType.DO_TASK,
 				description: doMatch[1].trim(),
-				rawText: trimmed,
+				rawText,
 			};
 		}
 
-		// /status
-		if (/^\/status\b/i.test(trimmed)) {
-			return { type: CommandType.STATUS, rawText: trimmed };
+		// /status [executionId]
+		const statusMatch = trimmed.match(/^\/?status(?:\s+(\d+))?\b/i);
+		if (statusMatch) {
+			return {
+				type: CommandType.STATUS,
+				executionId: statusMatch[1]
+					? Number.parseInt(statusMatch[1], 10)
+					: undefined,
+				rawText,
+			};
 		}
 
-		// /cancel
-		if (/^\/cancel\b/i.test(trimmed)) {
-			return { type: CommandType.CANCEL, rawText: trimmed };
+		// /cancel [executionId]
+		const cancelMatch = trimmed.match(/^\/?cancel(?:\s+(\d+))?\b/i);
+		if (cancelMatch) {
+			return {
+				type: CommandType.CANCEL,
+				executionId: cancelMatch[1]
+					? Number.parseInt(cancelMatch[1], 10)
+					: undefined,
+				rawText,
+			};
 		}
 
-		// /pause
-		if (/^\/pause\b/i.test(trimmed)) {
-			return { type: CommandType.PAUSE, rawText: trimmed };
+		// /pause [executionId]
+		const pauseMatch = trimmed.match(/^\/?pause(?:\s+(\d+))?\b/i);
+		if (pauseMatch) {
+			return {
+				type: CommandType.PAUSE,
+				executionId: pauseMatch[1]
+					? Number.parseInt(pauseMatch[1], 10)
+					: undefined,
+				rawText,
+			};
 		}
 
-		// /resume
-		if (/^\/resume\b/i.test(trimmed)) {
-			return { type: CommandType.RESUME, rawText: trimmed };
+		// /resume [executionId] [feedback]
+		const resumeMatch = trimmed.match(/^\/?resume(?:\s+(.+))?$/is);
+		if (resumeMatch) {
+			const args = resumeMatch[1]?.trim() ?? "";
+			const argMatch = args.match(/^(\d+)(?:\s+([\s\S]+))?$/);
+			return {
+				type: CommandType.RESUME,
+				executionId: argMatch
+					? Number.parseInt(argMatch[1], 10)
+					: undefined,
+				feedback: argMatch ? argMatch[2]?.trim() : args || undefined,
+				rawText,
+			};
 		}
 
 		// /devices
-		if (/^\/devices?\b/i.test(trimmed)) {
-			return { type: CommandType.DEVICES, rawText: trimmed };
+		if (/^\/?devices?\b/i.test(trimmed)) {
+			return { type: CommandType.DEVICES, rawText };
 		}
 
 		// /help
-		if (/^\/help\b/i.test(trimmed)) {
-			return { type: CommandType.HELP, rawText: trimmed };
+		if (/^\/?help\b/i.test(trimmed)) {
+			return { type: CommandType.HELP, rawText };
 		}
 
 
 		if (/^(?:task\s+list|\u4efb\u52a1\u5217\u8868)$/i.test(trimmed)) {
-			return { type: CommandType.LIST_TASKS, rawText: trimmed };
+			return { type: CommandType.LIST_TASKS, rawText };
 		}
 
 		const cnRunMatch = trimmed.match(/^(?:\u6267\u884c|\u8fd0\u884c)\s*[:\uff1a]?\s*(\d+)/);
@@ -74,7 +109,7 @@ export class CommandParserService {
 			return {
 				type: CommandType.RUN_TASK,
 				taskId: Number.parseInt(cnRunMatch[1], 10),
-				rawText: trimmed,
+				rawText,
 			};
 		}
 
@@ -83,27 +118,41 @@ export class CommandParserService {
 			return {
 				type: CommandType.DO_TASK,
 				description: cnDoMatch[1].trim(),
-				rawText: trimmed,
+				rawText,
 			};
 		}
 
 		if (/^\u72b6\u6001$/.test(trimmed)) {
-			return { type: CommandType.STATUS, rawText: trimmed };
+			return { type: CommandType.STATUS, rawText };
 		}
 		if (/^\u53d6\u6d88$/.test(trimmed)) {
-			return { type: CommandType.CANCEL, rawText: trimmed };
+			return { type: CommandType.CANCEL, rawText };
 		}
 		if (/^\u6682\u505c$/.test(trimmed)) {
-			return { type: CommandType.PAUSE, rawText: trimmed };
+			return { type: CommandType.PAUSE, rawText };
 		}
 		if (/^\u6062\u590d$/.test(trimmed)) {
-			return { type: CommandType.RESUME, rawText: trimmed };
+			return { type: CommandType.RESUME, rawText };
 		}
 		if (/^\u5e2e\u52a9$/.test(trimmed)) {
-			return { type: CommandType.HELP, rawText: trimmed };
+			return { type: CommandType.HELP, rawText };
 		}
 
 
 		return { type: CommandType.FREE_TEXT, rawText: trimmed };
+	}
+
+	private stripCommandPrefix(text: string, prefix: string): string {
+		const trimmed = text.trim();
+		if (!prefix) return trimmed;
+
+		const lowerText = trimmed.toLowerCase();
+		const lowerPrefix = prefix.toLowerCase();
+		if (lowerText !== lowerPrefix && !lowerText.startsWith(`${lowerPrefix} `)) {
+			return trimmed;
+		}
+
+		const withoutPrefix = trimmed.slice(prefix.length).trim();
+		return withoutPrefix || "help";
 	}
 }

--- a/server/apps/backend/src/modules/im-channel/command/command.types.ts
+++ b/server/apps/backend/src/modules/im-channel/command/command.types.ts
@@ -18,5 +18,6 @@ export interface ParsedCommand {
 	taskId?: number;
 	description?: string;
 	executionId?: number;
+	feedback?: string;
 	rawText: string;
 }

--- a/server/apps/backend/src/modules/im-channel/discord/discord-bot.service.ts
+++ b/server/apps/backend/src/modules/im-channel/discord/discord-bot.service.ts
@@ -1,0 +1,360 @@
+import { Injectable, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+	Client,
+	Events,
+	GatewayIntentBits,
+	REST,
+	Routes,
+	SlashCommandBuilder,
+	type ChatInputCommandInteraction,
+} from "discord.js";
+import { AppLogger } from "../../../common/log";
+import type { ImInboundMessage } from "../im-channel.types";
+
+@Injectable()
+export class DiscordBotService implements OnModuleInit, OnModuleDestroy {
+	private client: Client | null = null;
+	private enabled = false;
+	private commandPrefix = "!opengui";
+	private allowedGuildIds = new Set<string>();
+	private allowedChannelIds = new Set<string>();
+	private allowedUserIds = new Set<string>();
+
+	onMessage: ((message: ImInboundMessage) => Promise<void>) | null = null;
+
+	constructor(
+		private readonly logger: AppLogger,
+		private readonly configService: ConfigService,
+	) {
+		this.logger.setContext(DiscordBotService.name);
+	}
+
+	async onModuleInit() {
+		const token = this.configService.get("DISCORD_BOT_TOKEN", "");
+		if (!token) {
+			this.logger.log("Discord bot not configured, skipping");
+			return;
+		}
+
+		this.commandPrefix = this.configService.get(
+			"DISCORD_COMMAND_PREFIX",
+			"!opengui",
+		);
+		this.allowedGuildIds = this.parseIdList("DISCORD_ALLOWED_GUILD_IDS");
+		this.allowedChannelIds = this.parseIdList("DISCORD_ALLOWED_CHANNEL_IDS");
+		this.allowedUserIds = this.parseIdList("DISCORD_ALLOWED_USER_IDS");
+		this.enabled = true;
+
+		this.client = new Client({
+			intents: [
+				GatewayIntentBits.Guilds,
+				GatewayIntentBits.GuildMessages,
+				GatewayIntentBits.MessageContent,
+			],
+		});
+
+		this.client.once(Events.ClientReady, async (client) => {
+			this.logger.log(`[DiscordBot] Connected as ${client.user.tag}`);
+			try {
+				await this.registerSlashCommandsIfEnabled(token);
+			} catch (e) {
+				this.logger.error(
+					`Failed to register Discord slash commands: ${(e as Error).message}`,
+				);
+			}
+		});
+
+		this.client.on(Events.MessageCreate, async (message) => {
+			if (message.author.bot) return;
+			if (!this.hasCommandPrefix(message.content)) return;
+			if (
+				!this.isAllowed({
+					guildId: message.guildId ?? undefined,
+					channelId: message.channelId,
+					userId: message.author.id,
+				})
+			) {
+				return;
+			}
+
+			await this.onMessage?.({
+				platform: "discord",
+				conversationId: message.channelId,
+				platformUserId: message.author.id,
+				guildId: message.guildId ?? undefined,
+				text: this.stripCommandPrefix(message.content),
+			});
+		});
+
+		this.client.on(Events.InteractionCreate, async (interaction) => {
+			if (!interaction.isChatInputCommand()) return;
+			if (interaction.commandName !== "opengui") return;
+			await this.handleSlashCommand(interaction);
+		});
+
+		try {
+			await this.client.login(token);
+		} catch (e) {
+			this.enabled = false;
+			this.logger.error(`Failed to start Discord bot: ${(e as Error).message}`);
+			await this.client.destroy();
+			this.client = null;
+		}
+	}
+
+	async onModuleDestroy() {
+		this.enabled = false;
+		if (this.client) {
+			await this.client.destroy();
+			this.client = null;
+		}
+	}
+
+	get isEnabled(): boolean {
+		return this.enabled;
+	}
+
+	async sendMessage(channelId: string, text: string): Promise<void> {
+		if (!this.client) return;
+		try {
+			const channel = await this.client.channels.fetch(channelId);
+			const sendableChannel = channel as {
+				send?: (content: string) => Promise<unknown>;
+			} | null;
+			if (typeof sendableChannel?.send !== "function") return;
+			for (const chunk of this.splitMessage(text)) {
+				await sendableChannel.send(chunk);
+			}
+		} catch (e) {
+			this.logger.error(`Failed to send Discord message: ${(e as Error).message}`);
+		}
+	}
+
+	private async handleSlashCommand(interaction: ChatInputCommandInteraction) {
+		if (
+			!this.isAllowed({
+				guildId: interaction.guildId ?? undefined,
+				channelId: interaction.channelId,
+				userId: interaction.user.id,
+			})
+		) {
+			await interaction.reply({
+				content: "You are not allowed to control OpenGUI from here.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		const text = this.slashInteractionToText(interaction);
+		if (!text) {
+			await interaction.reply({
+				content: "Unsupported OpenGUI command.",
+				ephemeral: true,
+			});
+			return;
+		}
+
+		await interaction.reply("OpenGUI command received.");
+		await this.onMessage?.({
+			platform: "discord",
+			conversationId: interaction.channelId,
+			platformUserId: interaction.user.id,
+			guildId: interaction.guildId ?? undefined,
+			text,
+		});
+	}
+
+	private slashInteractionToText(
+		interaction: ChatInputCommandInteraction,
+	): string | null {
+		const subcommand = interaction.options.getSubcommand();
+		switch (subcommand) {
+			case "help":
+				return "/help";
+			case "devices":
+				return "/devices";
+			case "do":
+				return `/do ${interaction.options.getString("task", true)}`;
+			case "run":
+				return `/run ${interaction.options.getInteger("task_id", true)}`;
+			case "status": {
+				const executionId = interaction.options.getInteger("execution_id");
+				return executionId ? `/status ${executionId}` : "/status";
+			}
+			case "cancel":
+				return `/cancel ${interaction.options.getInteger("execution_id", true)}`;
+			case "pause":
+				return `/pause ${interaction.options.getInteger("execution_id", true)}`;
+			case "resume":
+				return `/resume ${interaction.options.getInteger(
+					"execution_id",
+					true,
+				)} ${interaction.options.getString("feedback", true)}`;
+			default:
+				return null;
+		}
+	}
+
+	private async registerSlashCommandsIfEnabled(token: string) {
+		const shouldRegister =
+			this.configService.get("DISCORD_REGISTER_COMMANDS", "false") === "true";
+		if (!shouldRegister) return;
+
+		const clientId = this.configService.get("DISCORD_CLIENT_ID", "");
+		if (!clientId) {
+			this.logger.warn(
+				"DISCORD_REGISTER_COMMANDS=true but DISCORD_CLIENT_ID is missing",
+			);
+			return;
+		}
+		if (this.allowedGuildIds.size === 0) {
+			this.logger.warn(
+				"DISCORD_REGISTER_COMMANDS=true but DISCORD_ALLOWED_GUILD_IDS is empty",
+			);
+			return;
+		}
+
+		const command = this.buildSlashCommand();
+		const rest = new REST({ version: "10" }).setToken(token);
+		for (const guildId of this.allowedGuildIds) {
+			await rest.put(Routes.applicationGuildCommands(clientId, guildId), {
+				body: [command.toJSON()],
+			});
+			this.logger.log(`[DiscordBot] Slash commands registered for guild ${guildId}`);
+		}
+	}
+
+	private buildSlashCommand() {
+		return new SlashCommandBuilder()
+			.setName("opengui")
+			.setDescription("Control OpenGUI phone tasks")
+			.addSubcommand((subcommand) =>
+				subcommand.setName("help").setDescription("Show OpenGUI commands"),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand.setName("devices").setDescription("List online devices"),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("do")
+					.setDescription("Create and run a new task")
+					.addStringOption((option) =>
+						option
+							.setName("task")
+							.setDescription("Task text")
+							.setRequired(true),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("run")
+					.setDescription("Run an existing task")
+					.addIntegerOption((option) =>
+						option
+							.setName("task_id")
+							.setDescription("Task ID")
+							.setRequired(true),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("status")
+					.setDescription("Show execution status")
+					.addIntegerOption((option) =>
+						option
+							.setName("execution_id")
+							.setDescription("Execution ID")
+							.setRequired(false),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("cancel")
+					.setDescription("Cancel an execution")
+					.addIntegerOption((option) =>
+						option
+							.setName("execution_id")
+							.setDescription("Execution ID")
+							.setRequired(true),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("pause")
+					.setDescription("Pause an execution")
+					.addIntegerOption((option) =>
+						option
+							.setName("execution_id")
+							.setDescription("Execution ID")
+							.setRequired(true),
+					),
+			)
+			.addSubcommand((subcommand) =>
+				subcommand
+					.setName("resume")
+					.setDescription("Resume an execution")
+					.addIntegerOption((option) =>
+						option
+							.setName("execution_id")
+							.setDescription("Execution ID")
+							.setRequired(true),
+					)
+					.addStringOption((option) =>
+						option
+							.setName("feedback")
+							.setDescription("Feedback for the paused task")
+							.setRequired(true),
+					),
+			);
+	}
+
+	private isAllowed(input: {
+		guildId?: string;
+		channelId: string;
+		userId: string;
+	}): boolean {
+		return (
+			this.matchesAllowList(this.allowedGuildIds, input.guildId) &&
+			this.matchesAllowList(this.allowedChannelIds, input.channelId) &&
+			this.matchesAllowList(this.allowedUserIds, input.userId)
+		);
+	}
+
+	private matchesAllowList(allowList: Set<string>, value?: string): boolean {
+		if (allowList.size === 0) return true;
+		return value ? allowList.has(value) : false;
+	}
+
+	private parseIdList(key: string): Set<string> {
+		const value = this.configService.get(key, "");
+		return new Set(
+			value
+				.split(",")
+				.map((item) => item.trim())
+				.filter(Boolean),
+		);
+	}
+
+	private stripCommandPrefix(text: string): string {
+		const withoutPrefix = text.trim().slice(this.commandPrefix.length).trim();
+		return withoutPrefix || "help";
+	}
+
+	private hasCommandPrefix(text: string): boolean {
+		const trimmed = text.trim().toLowerCase();
+		const prefix = this.commandPrefix.toLowerCase();
+		return trimmed === prefix || trimmed.startsWith(`${prefix} `);
+	}
+
+	private splitMessage(text: string): string[] {
+		const maxLength = 1900;
+		if (text.length <= maxLength) return [text];
+
+		const chunks: string[] = [];
+		for (let i = 0; i < text.length; i += maxLength) {
+			chunks.push(text.slice(i, i + maxLength));
+		}
+		return chunks;
+	}
+}

--- a/server/apps/backend/src/modules/im-channel/im-channel.module.ts
+++ b/server/apps/backend/src/modules/im-channel/im-channel.module.ts
@@ -2,6 +2,7 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { LogModule } from "../../common/log";
 import { TaskModule } from "../task/task.module";
+import { DiscordBotService } from "./discord/discord-bot.service";
 import { FeishuBotService } from "./feishu/feishu-bot.service";
 import { TelegramBotService } from "./telegram/telegram-bot.service";
 import { CommandParserService } from "./command/command-parser.service";
@@ -14,6 +15,12 @@ import { ImChannelService } from "./im-channel.service";
  */
 @Module({
 	imports: [ConfigModule, LogModule, TaskModule],
-	providers: [FeishuBotService, TelegramBotService, CommandParserService, ImChannelService],
+	providers: [
+		FeishuBotService,
+		TelegramBotService,
+		DiscordBotService,
+		CommandParserService,
+		ImChannelService,
+	],
 })
 export class ImChannelModule {}

--- a/server/apps/backend/src/modules/im-channel/im-channel.service.ts
+++ b/server/apps/backend/src/modules/im-channel/im-channel.service.ts
@@ -12,26 +12,30 @@ import { StandbyGateway } from "../../common/ws/standby.gateway";
 import { StandbySocketService } from "../../common/ws/standby-socket.service";
 import { TaskService } from "../task/task.service";
 import { TaskExecutionService } from "../task/task-execution.service";
+import { DiscordBotService } from "./discord/discord-bot.service";
 import { FeishuBotService } from "./feishu/feishu-bot.service";
 import { TelegramBotService } from "./telegram/telegram-bot.service";
 import { CommandParserService } from "./command/command-parser.service";
 import { CommandType } from "./command/command.types";
 import { DEFAULT_USER_ID } from "./im-channel.constants";
+import type {
+	ActiveImExecution,
+	ImInboundMessage,
+	ImPlatform,
+} from "./im-channel.types";
 
 /**
  *
  */
 @Injectable()
 export class ImChannelService implements OnModuleInit {
-	private readonly activeExecutions = new Map<
-		number,
-		{ userId: string; platform: "feishu" | "telegram"; taskName: string; startedAt: number }
-	>();
+	private readonly activeExecutions = new Map<number, ActiveImExecution>();
 
 	constructor(
 		private readonly logger: AppLogger,
 		private readonly feishuBot: FeishuBotService,
 		private readonly telegramBot: TelegramBotService,
+		private readonly discordBot: DiscordBotService,
 		private readonly commandParser: CommandParserService,
 		private readonly taskService: TaskService,
 		private readonly taskExecutionService: TaskExecutionService,
@@ -44,13 +48,27 @@ export class ImChannelService implements OnModuleInit {
 	onModuleInit() {
 		if (this.feishuBot.isEnabled) {
 			this.feishuBot.onMessage = (openId, text) =>
-				this.handleMessage(openId, text, "feishu");
+				this.handleMessage({
+					platform: "feishu",
+					conversationId: openId,
+					platformUserId: openId,
+					text,
+				});
 			this.logger.log("IM channel: Feishu bot registered");
 		}
 		if (this.telegramBot.isEnabled) {
 			this.telegramBot.onMessage = (chatId, text) =>
-				this.handleMessage(chatId, text, "telegram");
+				this.handleMessage({
+					platform: "telegram",
+					conversationId: chatId,
+					platformUserId: chatId,
+					text,
+				});
 			this.logger.log("IM channel: Telegram bot registered");
+		}
+		this.discordBot.onMessage = (message) => this.handleMessage(message);
+		if (this.discordBot.isEnabled) {
+			this.logger.log("IM channel: Discord bot registered");
 		}
 	}
 
@@ -58,47 +76,47 @@ export class ImChannelService implements OnModuleInit {
 
 	// ============================================================
 
-	private async handleMessage(userId: string, text: string, platform: "feishu" | "telegram"): Promise<void> {
-		const cmd = this.commandParser.parse(text);
+	private async handleMessage(message: ImInboundMessage): Promise<void> {
+		const cmd = this.commandParser.parse(message.text);
 
 		try {
 			switch (cmd.type) {
 				case CommandType.HELP:
-					await this.handleHelp(userId, platform);
+					await this.handleHelp(message);
 					break;
 				case CommandType.LIST_TASKS:
-					await this.handleListTasks(userId, platform);
+					await this.handleListTasks(message);
 					break;
 				case CommandType.RUN_TASK:
-					await this.handleRunTask(userId, cmd.taskId!, platform);
+					await this.handleRunTask(message, cmd.taskId!);
 					break;
 				case CommandType.DO_TASK:
-					await this.handleDoTask(userId, cmd.description!, platform);
+					await this.handleDoTask(message, cmd.description!);
 					break;
 				case CommandType.STATUS:
-					await this.handleStatus(userId, platform);
+					await this.handleStatus(message, cmd.executionId);
 					break;
 				case CommandType.CANCEL:
-					await this.handleCancel(userId, platform);
+					await this.handleCancel(message, cmd.executionId);
 					break;
 				case CommandType.PAUSE:
-					await this.handlePause(userId, platform);
+					await this.handlePause(message, cmd.executionId);
 					break;
 				case CommandType.RESUME:
-					await this.handleResume(userId, cmd.rawText, platform);
+					await this.handleResume(message, cmd.executionId, cmd.feedback);
 					break;
 				case CommandType.DEVICES:
-					await this.handleDevices(userId, platform);
+					await this.handleDevices(message);
 					break;
 				case CommandType.FREE_TEXT:
-					await this.handleFreeText(userId, cmd.rawText, platform);
+					await this.handleFreeText(message, cmd.rawText);
 					break;
 			}
 		} catch (e) {
 			this.logger.error(
 				`Command handler error: ${(e as Error).message}`,
 			);
-			await this.reply(userId, `❌ Processing failed: ${(e as Error).message}`, platform);
+			await this.reply(message, `❌ Processing failed: ${(e as Error).message}`);
 		}
 	}
 
@@ -106,34 +124,36 @@ export class ImChannelService implements OnModuleInit {
 
 	// ============================================================
 
-	private async handleHelp(userId: string, platform: "feishu" | "telegram") {
+	private async handleHelp(message: ImInboundMessage) {
 		await this.reply(
-			userId,
+			message,
 			[
 				"📱 OpenGUI Remote Control",
 				"",
 				"/tasks — View task list",
 				"/run <ID> — Run an existing task by ID",
-					"/do <description> — Create and run a new task",
-				"/status — View current execution status",
-				"/cancel — Cancel current execution",
-				"/pause — Pause current execution",
-				"/resume — Resume paused execution",
+				"/do <description> — Create and run a new task",
+				"/status [executionId] — View execution status",
+				"/cancel [executionId] — Cancel execution",
+				"/pause [executionId] — Pause execution",
+				"/resume [executionId] <feedback> — Resume paused execution",
 				"/devices — View online devices",
 				"/help — View this help",
 			].join("\n"),
-			platform,
 		);
 	}
 
-	private async handleListTasks(userId: string, platform: "feishu" | "telegram") {
+	private async handleListTasks(message: ImInboundMessage) {
 		const result = await this.taskService.getTaskList(DEFAULT_USER_ID, {
 			page: 1,
 			pageSize: 20,
 		});
 
 		if (!result.items.length) {
-			await this.reply(userId, "No tasks yet. Send /do <description> to create one.", platform);
+			await this.reply(
+				message,
+				"No tasks yet. Send /do <description> to create one.",
+			);
 			return;
 		}
 
@@ -144,29 +164,38 @@ export class ImChannelService implements OnModuleInit {
 			);
 		}
 		lines.push("", "Send /run <ID> to execute");
-		await this.reply(userId, lines.join("\n"), platform);
+		await this.reply(message, lines.join("\n"));
 	}
 
-	private async handleRunTask(userId: string, taskId: number, platform: "feishu" | "telegram") {
+	private async handleRunTask(message: ImInboundMessage, taskId: number) {
 		const device = this.standbySocketService.getOnlineDevice();
 		if (!device) {
-			await this.reply(userId, "❌ No online device. Start the app on the work phone first.", platform);
+			await this.reply(
+				message,
+				"❌ No online device. Start the app on the work phone first.",
+			);
 			return;
 		}
 
 		const task = await this.taskService.getTaskById(taskId, DEFAULT_USER_ID);
 		if (!task) {
-				await this.reply(userId, `❌ No task found with ID ${taskId}\nSend /tasks to view the list`, platform);
+			await this.reply(
+				message,
+				`❌ No task found with ID ${taskId}\nSend /tasks to view the list`,
+			);
 			return;
 		}
 
-		await this.dispatchExecution(userId, taskId, task.taskName, device, platform);
+		await this.dispatchExecution(message, taskId, task.taskName, device);
 	}
 
-	private async handleDoTask(userId: string, description: string, platform: "feishu" | "telegram") {
+	private async handleDoTask(message: ImInboundMessage, description: string) {
 		const device = this.standbySocketService.getOnlineDevice();
 		if (!device) {
-			await this.reply(userId, "❌ No online device. Start the app on the work phone first.", platform);
+			await this.reply(
+				message,
+				"❌ No online device. Start the app on the work phone first.",
+			);
 			return;
 		}
 
@@ -179,86 +208,122 @@ export class ImChannelService implements OnModuleInit {
 			taskDescription: description,
 		});
 
-		await this.reply(userId, `📝 Created task: ${name}`, platform);
-		await this.dispatchExecution(userId, task.id, name, device, platform);
+		await this.reply(message, `📝 Created task: ${name}`);
+		await this.dispatchExecution(message, task.id, name, device);
 	}
 
-	private async handleStatus(userId: string, platform: "feishu" | "telegram") {
-		if (this.activeExecutions.size === 0) {
-			await this.reply(userId, "No active execution", platform);
+	private async handleStatus(message: ImInboundMessage, executionId?: number) {
+		if (executionId) {
+			const execution = await this.taskExecutionService.getExecutionById(
+				executionId,
+				DEFAULT_USER_ID,
+			);
+			const info = this.activeExecutions.get(executionId);
+			const lines = [
+				`📊 Execution #${execution.id}`,
+				`Task ID: ${execution.taskId}`,
+				`Status: ${execution.executionStatus}`,
+			];
+			if (execution.executionResult) {
+				lines.push(`Result: ${execution.executionResult}`);
+			}
+			if (execution.statusMessage) {
+				lines.push(`Message: ${execution.statusMessage}`);
+			}
+			if (execution.currentStep) {
+				lines.push(`Current step: ${execution.currentStep}`);
+			}
+			if (info) {
+				lines.push(`Task: ${info.taskName}`);
+			}
+			await this.reply(message, lines.join("\n"));
+			return;
+		}
+
+		const activeExecutions = this.getActiveExecutionsForContext(message);
+		if (activeExecutions.length === 0) {
+			await this.reply(message, "No active execution");
 			return;
 		}
 
 		const lines = ["📊 Execution status", ""];
-		for (const [execId, info] of this.activeExecutions) {
+		for (const [execId, info] of activeExecutions) {
 			const elapsed = Math.floor((Date.now() - info.startedAt) / 1000);
 			const min = Math.floor(elapsed / 60);
 			const sec = elapsed % 60;
 			lines.push(`Task: ${info.taskName} (ID: ${execId})`);
 			lines.push(`Runtime: ${min}m ${sec}s`);
 		}
-		await this.reply(userId, lines.join("\n"), platform);
+		await this.reply(message, lines.join("\n"));
 	}
 
-	private async handleCancel(userId: string, platform: "feishu" | "telegram") {
-		const execId = this.getFirstActiveExecutionId();
+	private async handleCancel(message: ImInboundMessage, executionId?: number) {
+		const execId = this.getExecutionIdForContext(message, executionId);
 		if (!execId) {
-			await this.reply(userId, "No active execution", platform);
+			await this.reply(message, "No active execution");
 			return;
 		}
 		await this.taskExecutionService.cancelExecution(execId, DEFAULT_USER_ID);
-		await this.reply(userId, "⏹ Cancelled", platform);
+		await this.reply(message, `⏹ Cancelled execution #${execId}`);
 	}
 
-	private async handlePause(userId: string, platform: "feishu" | "telegram") {
-		const execId = this.getFirstActiveExecutionId();
+	private async handlePause(message: ImInboundMessage, executionId?: number) {
+		const execId = this.getExecutionIdForContext(message, executionId);
 		if (!execId) {
-			await this.reply(userId, "No active execution", platform);
+			await this.reply(message, "No active execution");
 			return;
 		}
 		await this.taskExecutionService.pauseExecution(execId, DEFAULT_USER_ID);
-		await this.reply(userId, "⏸ Paused. Use /resume to resume or /cancel to cancel.", platform);
+		await this.reply(
+			message,
+			`⏸ Paused execution #${execId}. Use /resume ${execId} <feedback> to resume or /cancel ${execId} to cancel.`,
+		);
 	}
 
-	private async handleResume(userId: string, feedback: string | undefined, platform: "feishu" | "telegram") {
-		const execId = this.getFirstActiveExecutionId();
+	private async handleResume(
+		message: ImInboundMessage,
+		executionId: number | undefined,
+		feedback: string | undefined,
+	) {
+		const execId = this.getExecutionIdForContext(message, executionId);
 		if (!execId) {
-			await this.reply(userId, "No resumable task", platform);
+			await this.reply(message, "No resumable task");
 			return;
 		}
 		await this.taskExecutionService.resumeExecution(
 			execId,
 			DEFAULT_USER_ID,
+			feedback ? { feedback } : undefined,
 		);
-		await this.reply(userId, "▶️ Execution resumed", platform);
+		await this.reply(message, `▶️ Execution #${execId} resumed`);
 	}
 
-	private async handleDevices(userId: string, platform: "feishu" | "telegram") {
+	private async handleDevices(message: ImInboundMessage) {
 		const devices = this.standbySocketService.getOnlineDevices();
 		if (devices.length === 0) {
-			await this.reply(userId, "No online devices", platform);
+			await this.reply(message, "No online devices");
 			return;
 		}
 		const lines = ["📱 Online Devices", ""];
 		for (const d of devices) {
 			lines.push(`• ${d.deviceName || d.deviceId}`);
 		}
-		await this.reply(userId, lines.join("\n"), platform);
+		await this.reply(message, lines.join("\n"));
 	}
 
-	private async handleFreeText(userId: string, text: string, platform: "feishu" | "telegram") {
-		const execId = this.getFirstActiveExecutionId();
+	private async handleFreeText(message: ImInboundMessage, text: string) {
+		const execId = this.getExecutionIdForContext(message);
 		if (execId) {
 			await this.taskExecutionService.resumeExecution(
 				execId,
 				DEFAULT_USER_ID,
 				{ feedback: text },
 			);
-			await this.reply(userId, "▶️ Reply received. Continuing execution...", platform);
+			await this.reply(message, "▶️ Reply received. Continuing execution...");
 			return;
 		}
 
-		await this.reply(userId, "Send /help to view available commands", platform);
+		await this.reply(message, "Send /help to view available commands");
 	}
 
 	// ============================================================
@@ -271,7 +336,7 @@ export class ImChannelService implements OnModuleInit {
 		if (!info) return;
 
 		await this.reply(
-			info.userId,
+			info,
 			[
 				"🔔 Task needs your help",
 				"",
@@ -279,7 +344,6 @@ export class ImChannelService implements OnModuleInit {
 				"",
 				"Reply with text to continue, or send /cancel to cancel.",
 			].join("\n"),
-			info.platform,
 		);
 	}
 
@@ -321,7 +385,7 @@ export class ImChannelService implements OnModuleInit {
 					.join("\n");
 		}
 
-		await this.reply(info.userId, text, info.platform);
+		await this.reply(info, text);
 	}
 
 	private lastActionThoughtTime = new Map<number, number>();
@@ -338,7 +402,7 @@ export class ImChannelService implements OnModuleInit {
 		};
 		const label = phaseNames[event.phase];
 		if (label) {
-			await this.reply(info.userId, label, info.platform);
+			await this.reply(info, label);
 		}
 	}
 
@@ -352,7 +416,7 @@ export class ImChannelService implements OnModuleInit {
 		if (now - last < 10_000) return;
 		this.lastActionThoughtTime.set(event.executionId, now);
 
-		await this.reply(info.userId, `> ${event.content}`, info.platform);
+		await this.reply(info, `> ${event.content}`);
 	}
 
 	// ============================================================
@@ -360,11 +424,10 @@ export class ImChannelService implements OnModuleInit {
 	// ============================================================
 
 	private async dispatchExecution(
-		userId: string,
+		message: ImInboundMessage,
 		taskId: number,
 		taskName: string,
 		device: NonNullable<ReturnType<StandbySocketService["getOnlineDevice"]>>,
-		platform: "feishu" | "telegram",
 	) {
 		const result = await this.taskExecutionService.executeTask(
 			taskId,
@@ -373,16 +436,16 @@ export class ImChannelService implements OnModuleInit {
 		);
 
 		this.activeExecutions.set(result.executionId, {
-			userId,
-			platform,
+			platform: message.platform,
+			conversationId: message.conversationId,
+			platformUserId: message.platformUserId,
 			taskName,
 			startedAt: Date.now(),
 		});
 
 		await this.reply(
-			userId,
+			message,
 			`▶️ Starting execution: ${taskName}\nDevice: ${device.deviceName || device.deviceId}`,
-			platform,
 		);
 
 		this.standbyGateway.dispatchToDevice(device, {
@@ -392,18 +455,45 @@ export class ImChannelService implements OnModuleInit {
 		});
 	}
 
-	private getFirstActiveExecutionId(): number | null {
-		for (const [id] of this.activeExecutions) {
+	private getExecutionIdForContext(
+		message: ImInboundMessage,
+		executionId?: number,
+	): number | null {
+		if (executionId) return executionId;
+		for (const [id] of this.getActiveExecutionsForContext(message)) {
 			return id;
 		}
 		return null;
 	}
 
-	private async reply(userId: string, text: string, platform?: "feishu" | "telegram") {
-		if (platform === "telegram" && this.telegramBot.isEnabled) {
-			await this.telegramBot.sendMessage(userId, text);
-		} else if (this.feishuBot.isEnabled) {
-			await this.feishuBot.sendMessage(userId, text);
+	private getActiveExecutionsForContext(
+		message: ImInboundMessage,
+	): Array<[number, ActiveImExecution]> {
+		return Array.from(this.activeExecutions.entries()).filter(([, info]) =>
+			this.isSameConversation(info, message),
+		);
+	}
+
+	private isSameConversation(
+		info: ActiveImExecution,
+		message: ImInboundMessage,
+	): boolean {
+		return (
+			info.platform === message.platform &&
+			info.conversationId === message.conversationId
+		);
+	}
+
+	private async reply(
+		target: { platform: ImPlatform; conversationId: string },
+		text: string,
+	) {
+		if (target.platform === "telegram" && this.telegramBot.isEnabled) {
+			await this.telegramBot.sendMessage(target.conversationId, text);
+		} else if (target.platform === "discord" && this.discordBot.isEnabled) {
+			await this.discordBot.sendMessage(target.conversationId, text);
+		} else if (target.platform === "feishu" && this.feishuBot.isEnabled) {
+			await this.feishuBot.sendMessage(target.conversationId, text);
 		}
 	}
 }

--- a/server/apps/backend/src/modules/im-channel/im-channel.types.ts
+++ b/server/apps/backend/src/modules/im-channel/im-channel.types.ts
@@ -1,0 +1,17 @@
+export type ImPlatform = "feishu" | "telegram" | "discord";
+
+export interface ImInboundMessage {
+	platform: ImPlatform;
+	conversationId: string;
+	platformUserId: string;
+	text: string;
+	guildId?: string;
+}
+
+export interface ActiveImExecution {
+	platform: ImPlatform;
+	conversationId: string;
+	platformUserId: string;
+	taskName: string;
+	startedAt: number;
+}

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -171,6 +171,9 @@ importers:
       deepagents:
         specifier: ^1.3.1
         version: 1.8.6(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(langsmith@0.4.12(@opentelemetry/api@1.9.1)(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@5.23.2(ws@8.20.0)(zod@4.3.6)))(openai@5.23.2(ws@8.20.0)(zod@4.3.6))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(ws@8.20.0)(zod-to-json-schema@3.25.2(zod@4.3.6))
+      discord.js:
+        specifier: ^14.26.3
+        version: 14.26.3
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -812,24 +815,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.9':
     resolution: {integrity: sha512-4adnkAUi6K4C/emPRgYznMOcLlUqZdXWM6aIui4VP4LraE764g6Q4YguygnAUoxKjKIXIWPteKMgRbN0wsgwcg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.9':
     resolution: {integrity: sha512-5TD+WS9v5vzXKzjetF0hgoaNFHMcpQeBUwKKVi3JbG1e9UCrFuUK3Gt185fyTzvRdwYkJJEMqglRPjmesmVv4A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.9':
     resolution: {integrity: sha512-L10na7POF0Ks/cgLFNF1ZvIe+X4onLkTi5oP9hY+Rh60Q+7fWzKDDCeGyiHUFf1nGIa9dQOOUPGe2MyYg8nMSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.9':
     resolution: {integrity: sha512-aDZr0RBC3sMGJOU10BvG7eZIlWLK/i51HRIfScE2lVhfts2dQTreowLiJJd+UYg/tHKxS470IbzpuKmd0MiD6g==}
@@ -887,6 +894,34 @@ packages:
 
   '@dabh/diagnostics@2.0.8':
     resolution: {integrity: sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==}
+
+  '@discordjs/builders@1.14.1':
+    resolution: {integrity: sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@1.5.3':
+    resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/formatters@0.6.2':
+    resolution: {integrity: sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==}
+    engines: {node: '>=16.11.0'}
+
+  '@discordjs/rest@2.6.1':
+    resolution: {integrity: sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/util@1.2.0':
+    resolution: {integrity: sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==}
+    engines: {node: '>=18'}
+
+  '@discordjs/ws@1.2.3':
+    resolution: {integrity: sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==}
+    engines: {node: '>=16.11.0'}
 
   '@electric-sql/pglite-socket@0.1.1':
     resolution: {integrity: sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==}
@@ -1126,56 +1161,66 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
@@ -2399,6 +2444,22 @@ packages:
     resolution: {integrity: sha512-8e+bU+OyAIpAGXQanOopZa5YEK+yHKw84dhhihcCotF40MSNFbVHjQ4xM5hf4QndlqDGfXIuvXmoOMuDATa/gA==}
     engines: {node: '>=18'}
 
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
+    engines: {node: '>=v16'}
+
+  '@sapphire/snowflake@3.5.3':
+    resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@sapphire/snowflake@3.5.5':
+    resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -2862,41 +2923,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2924,6 +2993,10 @@ packages:
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
+
+  '@vladfrangu/async_event_emitter@2.4.7':
+    resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
+    engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   '@voltagent/a2a-server@1.0.2':
     resolution: {integrity: sha512-WIPDM0iYvcEPKbwbYt9n1TQv9jjRUcxvAgeCAiVD8EzYYrJvHXHCHC6satpeQF8N/0jFKtEMq8a+5/3cfwM/hQ==}
@@ -4121,6 +4194,13 @@ packages:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
+  discord-api-types@0.38.47:
+    resolution: {integrity: sha512-XgXQodHQBAE6kfD7kMvVo30863iHX1LHSqNq6MGUTDwIFCCvHva13+rwxyxVXDqudyApMNAd32PGjgVETi5rjA==}
+
+  discord.js@14.26.3:
+    resolution: {integrity: sha512-XEKtYn28YFsiJ5l4fLRyikdbo6RD5oFyqfVHQlvXz2104JhH/E8slN28dbky05w3DCrJcNVWvhVvcJCTSl/KIg==}
+    engines: {node: '>=18'}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
@@ -4592,7 +4672,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -5346,6 +5426,9 @@ packages:
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
 
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
@@ -5388,6 +5471,9 @@ packages:
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  magic-bytes.js@1.13.0:
+    resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -6868,6 +6954,9 @@ packages:
       typescript: '*'
       webpack: ^5.0.0
 
+  ts-mixer@6.0.4:
+    resolution: {integrity: sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -6964,6 +7053,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@6.24.1:
+    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+    engines: {node: '>=18.17'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -7953,6 +8046,55 @@ snapshots:
       '@so-ric/colorspace': 1.1.6
       enabled: 2.0.0
       kuler: 2.0.0
+
+  '@discordjs/builders@1.14.1':
+    dependencies:
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/util': 1.2.0
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      ts-mixer: 6.0.4
+      tslib: 2.8.1
+
+  '@discordjs/collection@1.5.3': {}
+
+  '@discordjs/collection@2.1.1': {}
+
+  '@discordjs/formatters@0.6.2':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/rest@2.6.1':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@sapphire/snowflake': 3.5.5
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+
+  '@discordjs/util@1.2.0':
+    dependencies:
+      discord-api-types: 0.38.47
+
+  '@discordjs/ws@1.2.3':
+    dependencies:
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@sapphire/async-queue': 1.5.5
+      '@types/ws': 8.18.1
+      '@vladfrangu/async_event_emitter': 2.4.7
+      discord-api-types: 0.38.47
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':
     dependencies:
@@ -9706,6 +9848,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@sapphire/async-queue@1.5.5': {}
+
+  '@sapphire/shapeshift@4.0.0':
+    dependencies:
+      fast-deep-equal: 3.1.3
+      lodash: 4.17.23
+
+  '@sapphire/snowflake@3.5.3': {}
+
+  '@sapphire/snowflake@3.5.5': {}
+
   '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.34.48': {}
@@ -10011,7 +10164,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
       '@types/qs': 6.15.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10072,7 +10225,7 @@ snapshots:
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
 
   '@types/luxon@3.7.1': {}
 
@@ -10125,12 +10278,12 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
 
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
 
   '@types/send@1.2.1':
     dependencies:
@@ -10139,7 +10292,7 @@ snapshots:
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
       '@types/send': 0.17.6
 
   '@types/serve-static@2.2.0':
@@ -10176,7 +10329,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -10251,6 +10404,8 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vercel/oidc@3.1.0': {}
+
+  '@vladfrangu/async_event_emitter@2.4.7': {}
 
   '@voltagent/a2a-server@1.0.2(@voltagent/core@1.5.2(@ai-sdk/provider-utils@3.0.22(zod@4.3.6))(@cfworker/json-schema@4.1.1)(@voltagent/logger@1.0.4(@opentelemetry/api@1.9.1))(ai@5.0.161(zod@4.3.6))(zod@4.3.6))':
     dependencies:
@@ -11662,6 +11817,27 @@ snapshots:
 
   diff@4.0.4: {}
 
+  discord-api-types@0.38.47: {}
+
+  discord.js@14.26.3:
+    dependencies:
+      '@discordjs/builders': 1.14.1
+      '@discordjs/collection': 1.5.3
+      '@discordjs/formatters': 0.6.2
+      '@discordjs/rest': 2.6.1
+      '@discordjs/util': 1.2.0
+      '@discordjs/ws': 1.2.3
+      '@sapphire/snowflake': 3.5.3
+      discord-api-types: 0.38.47
+      fast-deep-equal: 3.1.3
+      lodash.snakecase: 4.1.1
+      magic-bytes.js: 1.13.0
+      tslib: 2.8.1
+      undici: 6.24.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -12968,7 +13144,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 24.12.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -13268,6 +13444,8 @@ snapshots:
 
   lodash.pickby@4.6.0: {}
 
+  lodash.snakecase@4.1.1: {}
+
   lodash@4.17.23: {}
 
   log-symbols@4.1.0:
@@ -13303,6 +13481,8 @@ snapshots:
   lru.min@1.1.4: {}
 
   luxon@3.7.2: {}
+
+  magic-bytes.js@1.13.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -15055,6 +15235,8 @@ snapshots:
       typescript: 5.9.2
       webpack: 5.104.1(esbuild@0.25.12)
 
+  ts-mixer@6.0.4: {}
+
   ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -15144,6 +15326,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@6.24.1: {}
 
   unified@11.0.5:
     dependencies:

--- a/server/start.sh
+++ b/server/start.sh
@@ -112,16 +112,26 @@ fi
 
 set -a; source "$ENV_FILE" 2>/dev/null || true; set +a
 
+MODEL_CONFIG_MISSING=0
 if [ -z "$VLM_API_KEY" ]; then
-  warn "VLM_API_KEY is not set. Please edit .env."
+  warn "VLM_API_KEY is not set."
+  MODEL_CONFIG_MISSING=1
 fi
 
 if [ -z "$VLM_MODEL" ]; then
-  warn "VLM_MODEL is not set. Please edit .env."
+  warn "VLM_MODEL is not set."
+  MODEL_CONFIG_MISSING=1
 fi
 
 if [ -z "$VLM_BASE_URL" ]; then
-  warn "VLM_BASE_URL is not set. Please edit .env."
+  warn "VLM_BASE_URL is not set."
+  MODEL_CONFIG_MISSING=1
+fi
+
+if [ "$MODEL_CONFIG_MISSING" -eq 1 ]; then
+  warn "Graph agent model config is incomplete. The backend can start, but task execution will fail until VLM_* is configured in $ENV_FILE."
+else
+  info "Graph agent model config detected: VLM_MODEL=$VLM_MODEL"
 fi
 
 info ".env loaded"
@@ -225,7 +235,7 @@ fi
 # --------------------------------------------------
 info "Starting OpenGUI Server ..."
 echo ""
-echo "  The backend will print API docs and GitHub star links after startup."
+echo "  The backend will print the local API docs URL and project link after startup."
 echo ""
 
 pnpm backend


### PR DESCRIPTION
## Summary

- Add a Discord bot IM channel for remote OpenGUI Android task dispatch.
- Support prefix commands and guild-scoped slash commands.
- Add Discord allowlists for guild, channel, and user IDs.
- Document Discord setup in English, Simplified Chinese, and Japanese.
- Clarify backend `.env.example`, startup checks, and graph-agent `VLM_*` configuration.

## Behavior

- If `DISCORD_BOT_TOKEN` is empty, the backend starts normally and skips Discord.
- Discord web, Mac, and Windows clients work through the same Discord API bot flow.
- Android does not need a Discord-specific APK change.
- Task progress and final results are posted back to the same Discord channel.

## Validation

- `pnpm --filter backend test -- command-parser.service.spec.ts`
- `pnpm --filter backend build`
- `git diff --check`
- `bash -n server/start.sh`
- Checked local Markdown links.
- Checked staged files for `.env`, APKs, icon drafts, and secret-like values.

## Security Notes

- No real Discord token, API key, or local `.env` file is included.
- Discord task execution is guarded by optional guild/channel/user allowlists.
- Prefix commands require Discord Message Content Intent.
