### PR TITLE
Add community onboarding and growth launch kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report something that is not working in OpenGUI.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve OpenGUI. The most useful reports include the phone/emulator setup, backend logs, and the exact task that failed.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the failure and what you expected instead.
+      placeholder: The Android client connected, but the task stopped after...
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Include the task prompt, command, or app flow if possible.
+      placeholder: |
+        1. Start backend with ./start.sh
+        2. Install APK v0.1.1
+        3. Run task...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      placeholder: v0.1.1 or commit SHA
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where did it happen?
+      options:
+        - Android client
+        - Backend
+        - Bootstrap skill
+        - Discord / IM channel
+        - Documentation
+        - Other
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or screen recording
+      description: Paste relevant backend logs, Android logs, screenshots, or a short recording link.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a workflow, integration, or improvement for OpenGUI.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        OpenGUI is most useful when feature requests are grounded in a real mobile workflow. Tell us what phone task you want to automate and how you would judge success.
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow
+      description: What should OpenGUI do on the phone?
+      placeholder: I want a standby Android phone to...
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this useful?
+      description: Explain the user, team, or deployment scenario.
+    validations:
+      required: true
+  - type: textarea
+    id: desired
+    attributes:
+      label: Desired behavior
+      description: What should the backend, Android client, or IM channel return?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Android automation
+        - Backend graph / task state
+        - Model routing
+        - IM channel
+        - Documentation
+        - Developer tooling
+        - Other

--- a/.github/ISSUE_TEMPLATE/use_case.yml
+++ b/.github/ISSUE_TEMPLATE/use_case.yml
@@ -1,0 +1,26 @@
+name: Share a use case
+description: Share a real deployment idea or experiment for OpenGUI.
+title: "[Use case]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use cases help shape the roadmap. If you tried OpenGUI, tell us what worked, what failed, and which phone workflow matters most.
+  - type: textarea
+    id: scenario
+    attributes:
+      label: Scenario
+      description: What phone-based workflow do you want to run?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Device, Android version, backend setup, model provider, and app(s) involved.
+  - type: textarea
+    id: success
+    attributes:
+      label: What would make this successful?
+      description: Describe the result, duration, reliability, or output format you need.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Summary
+
+- 
+
+## Area
+
+- [ ] Android client
+- [ ] Backend
+- [ ] Bootstrap skill / docs
+- [ ] IM channel
+- [ ] Tests / tooling
+
+## Verification
+
+- [ ] I ran the relevant server checks
+- [ ] I built or tested the Android client
+- [ ] I updated docs or examples if behavior changed
+
+## Notes for reviewers
+
+Link related issues and call out any setup, migration, or device requirements.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@
 - `[2026.5.7]` Hardened local startup to avoid common PostgreSQL and Redis port conflicts during Docker-based backend setup.
 - `[2026.5.1]` Improved backend onboarding with `.env.example`, startup checks, and graph-agent VLM environment configuration.
 
+## Try It, Discuss It, Contribute
+
+- **Download the Android test APK** from the latest [GitHub release](https://github.com/Core-Mate/OpenGUI/releases/latest).
+- **Follow the setup guide** in [docs/get-started.md](./docs/get-started.md) or ask Claude/Codex to run [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md).
+- **Share a real phone workflow** by opening a [use case issue](https://github.com/Core-Mate/OpenGUI/issues/new/choose).
+- **Pick a starter contribution** from [ROADMAP.md](./ROADMAP.md) or the `good first issue` label.
+- **Join the Discord community**: https://discord.gg/pqHHw7XgJ3
+
 ## What You Can Do with OpenGUI
 
 OpenGUI lets AI operate real Android phones.
@@ -30,8 +38,6 @@ You can use the same repository in four practical ways:
 - **Run shipped workflows**: the repository already includes a runnable backend, Android client, standby dispatch path, and a set of built-in task capabilities.
 - **Let Claude or Codex bootstrap it for you**: point the model at [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md), describe the goal in plain language, and let it handle setup, build, install, and local debugging.
 - **Operate phones as remote workers**: dispatch tasks through Feishu, Telegram, Discord, or REST API, keep devices on standby, and get structured results back from the backend.
-
-- join the Discord community: https://discord.gg/pqHHw7XgJ3
 
 ## Highlights
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,29 @@
+# OpenGUI Roadmap
+
+OpenGUI is a source-available AI mobile operator system for real Android phones. The roadmap below is meant to make the next useful contributions visible to users and contributors.
+
+## Near Term
+
+- Improve first-run setup for the backend and Android client.
+- Publish more runnable task examples for common phone workflows.
+- Strengthen standby device dispatch through REST, Discord, Telegram, and Feishu.
+- Add clearer logs and failure recovery for long-running mobile tasks.
+- Document model-routing profiles for cost, speed, and quality tradeoffs.
+
+## Contribution Ideas
+
+- Add end-to-end setup screenshots for a physical Android phone.
+- Add emulator setup notes for macOS, Linux, and Windows.
+- Create example task prompts for X, Reddit, Hacker News, Telegram, WeChat, Weibo, and Xiaohongshu.
+- Add troubleshooting guides for backend connection, AccessibilityService, overlay permissions, and battery optimization.
+- Improve developer tests around task state, standby dispatch, and executor graph retries.
+- Add small integrations that make OpenGUI easier to trigger from external tools.
+
+## What Feedback Helps Most
+
+- Real phone workflows you want to automate.
+- Setup logs from failed installs or first runs.
+- Reports from long-running tasks that need review, retry, or recovery.
+- Model provider profiles that worked well or failed in practice.
+
+Open an issue with a bug, feature request, or use case whenever you have concrete feedback.

--- a/docs/growth-launch-kit.md
+++ b/docs/growth-launch-kit.md
@@ -1,0 +1,147 @@
+# OpenGUI Growth Launch Kit
+
+This launch kit is for honest community growth: show the project clearly, invite real use cases, and make it easy for developers to try the APK or contribute.
+
+## Current Proof Points
+
+- Repository: https://github.com/Core-Mate/OpenGUI
+- Homepage: https://opengui.ai/
+- Latest APK: https://github.com/Core-Mate/OpenGUI/releases/latest
+- Current positioning: AI mobile operator for real Android phones.
+- Early traction: 100+ GitHub stars, 13 forks, and 40 downloads on the v0.1.1 debug APK as of 2026-05-12.
+- New contribution entry points: issues #9 through #14.
+
+## Core Message
+
+OpenGUI lets an AI operate real Android phones for long-running mobile workflows. It combines a backend graph, Android AccessibilityService execution, standby device dispatch, and model routing so phones can act like remote workers for research, social media, app workflows, and structured mobile tasks.
+
+## Hacker News Draft
+
+Title:
+
+```text
+Show HN: OpenGUI - an AI operator for real Android phones
+```
+
+Body:
+
+```text
+Hi HN, we are building OpenGUI, a source-available AI mobile operator system for real Android phones.
+
+The goal is to move beyond short phone-agent demos. OpenGUI has a backend graph for task state, an Android client for screenshots and AccessibilityService actions, standby dispatch through REST/IM channels, and model routing so planning and VLM execution can use different providers.
+
+Example workflows:
+- collect recent posts for a topic from an Android app
+- read and summarize Reddit or Hacker News threads on a live phone
+- trigger phone tasks remotely from Discord, Telegram, Feishu, or REST
+- run longer mobile workflows with progress, review, and recovery
+
+The repo includes setup docs and a debug APK release for testing:
+https://github.com/Core-Mate/OpenGUI
+
+We especially want feedback on real phone workflows, setup failures, and where people would trust or not trust this kind of system.
+```
+
+## Reddit Draft
+
+Suggested communities: `r/LocalLLaMA`, `r/MachineLearning`, `r/androiddev`, `r/opensource`, and specific automation communities where self-promotion rules allow it.
+
+Title:
+
+```text
+OpenGUI: source-available AI operator for real Android phones
+```
+
+Body:
+
+```text
+I am working on OpenGUI, a source-available system that lets AI operate real Android phones.
+
+It is built around a backend task graph, Android AccessibilityService execution, screenshot/VLM loops, standby device dispatch, and model routing. The practical goal is to run phone-based workflows that need more state and recovery than a short demo loop.
+
+Repo: https://github.com/Core-Mate/OpenGUI
+Latest APK: https://github.com/Core-Mate/OpenGUI/releases/latest
+
+Useful feedback would be:
+- what Android workflows you would actually want to automate
+- where a physical phone is required vs. an emulator
+- what setup step fails first
+- what model/provider mix works for cost and reliability
+
+There are starter issues open for physical-device setup docs, emulator setup notes, troubleshooting, example prompts, and model-routing profiles.
+```
+
+## X / Twitter Thread Draft
+
+```text
+We are building OpenGUI: an AI mobile operator for real Android phones.
+
+Instead of only driving a phone from a laptop demo loop, OpenGUI has:
+- backend task graph
+- Android AccessibilityService execution
+- screenshot/VLM action loop
+- standby device dispatch
+- model routing by role
+
+Repo: https://github.com/Core-Mate/OpenGUI
+```
+
+```text
+Why phones?
+
+A lot of useful workflows still live inside mobile apps: research, social, messaging, local services, creator tools, and operations dashboards.
+
+OpenGUI is for long-running phone tasks with state, review, retry, and structured results.
+```
+
+```text
+We just opened contribution and feedback issues:
+- physical Android setup docs
+- emulator setup notes
+- troubleshooting guide
+- runnable task prompt examples
+- model routing profiles
+- real use case collection
+
+Try the APK and tell us what breaks:
+https://github.com/Core-Mate/OpenGUI/releases/latest
+```
+
+## Discord / Community Draft
+
+```text
+We are opening up OpenGUI for more external feedback.
+
+OpenGUI is a source-available AI operator for real Android phones: backend graph, Android client, AccessibilityService execution, standby dispatch, and model routing.
+
+Repo: https://github.com/Core-Mate/OpenGUI
+Latest APK: https://github.com/Core-Mate/OpenGUI/releases/latest
+
+We are looking for real phone workflows, setup reports, and contributors for docs/examples/troubleshooting. Good entry issues are now open in the repo.
+```
+
+## Outreach Order
+
+1. Merge the community onboarding PR.
+2. Pin or highlight issue #14 for use case collection.
+3. Post to the project Discord with the Discord draft.
+4. Post the X thread and link to issue #14.
+5. Post to Hacker News only when someone can monitor comments for the next 2 hours.
+6. Post to one Reddit community at a time after checking that community's self-promotion rules.
+7. Reply to every substantive comment with a concrete link: APK, setup docs, issue #14, or a relevant starter issue.
+
+## Channel Notes
+
+- **Hacker News**: use a neutral `Show HN` title, link the GitHub repo, and have a builder available to answer comments for at least 2 hours. Do not ask anyone for upvotes or comments.
+- **r/androiddev**: lead with technical implementation detail and source code. Avoid app-store-style copy. Good angle: Android AccessibilityService execution, emulator vs. physical device setup, and backend/device networking.
+- **r/LocalLLaMA**: treat as high-risk for self-promotion. Post only if the angle is model routing, local/open-compatible endpoints, or VLM cost/reliability, and make the post useful without requiring a click.
+- **r/opensource**: lead with contribution areas and licensing clarity. Since OpenGUI is BUSL source-available, be explicit rather than calling it OSI open source.
+- **X / Twitter**: use the thread to drive people to the GitHub repo and issue #14. Do not ask for stars; ask for real phone workflows and setup feedback.
+- **Discord / existing community**: post first here because the audience is already opted in and can sanity-check the message before broader launch.
+
+## Do Not Do
+
+- Do not buy stars, ask for fake stars, or trade stars.
+- Do not mass-post the same text across communities.
+- Do not create fake issues or sockpuppet discussion.
+- Do not post into communities whose rules prohibit project promotion.


### PR DESCRIPTION
## Summary

This PR improves the GitHub-to-community conversion path for OpenGUI:

- adds issue templates for bugs, feature requests, and real use cases
- adds a PR template so future contributions arrive with verification context
- adds a public ROADMAP with near-term contribution areas
- adds a README section that points visitors to the APK, setup guide, roadmap, issues, and Discord
- adds `docs/growth-launch-kit.md` with honest launch copy for HN, Reddit, X, and Discord

## Growth intent

The repo now has clearer actions for people who arrive from external posts: try the APK, share a use case, pick a starter issue, or join Discord. This should improve conversion from page views into stars, issues, and useful feedback.

## Related issues

Supports the new community entry points opened in #9, #10, #11, #12, #13, and #14.

## Verification

- Parsed all `.github/ISSUE_TEMPLATE/*.yml` files with Ruby YAML loader
- Reviewed generated Markdown locally