### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Something did not work as expected.
+title: ""
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. A short, concrete report is enough.
+
+        Please do not paste API keys, private screenshots, tokens, or full `.env` files. Security issues should be reported privately through SECURITY.md.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the problem in a few sentences.
+      placeholder: I started the backend and opened the Android app, but the device never appeared in the CLI device list.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: What did you try?
+      description: Share the commands or steps that led to the problem.
+      placeholder: |
+        cd server && ./start.sh
+        pnpm opengui -- devices --json
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Paste the relevant output or attach screenshots after redacting secrets.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in what you know. It is okay to leave unknown fields blank.
+      value: |
+        - OS:
+        - Node.js:
+        - pnpm:
+        - Android device or emulator:
+        - OpenGUI commit:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/Core-Mate/OpenGUI/security/policy
+    about: Please report security vulnerabilities privately instead of opening a public issue.
+  - name: OpenGUI documentation
+    url: https://github.com/Core-Mate/OpenGUI#readme
+    about: Start with the README and setup docs if you are trying OpenGUI for the first time.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a change that would make OpenGUI more useful.
+title: ""
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing an idea. Please keep it grounded in a workflow you actually want to run.
+  - type: textarea
+    id: workflow
+    attributes:
+      label: What are you trying to do?
+      description: Describe the task, app, or workflow this would help with.
+      placeholder: I want to run a phone task on a specific standby device without guessing which device will be selected.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to change?
+      description: A rough idea is fine.
+      placeholder: It would help if the docs showed how to pick a device from the CLI output.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Notes or examples
+      description: Add links, examples, screenshots, or related issues. Redact private content.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/setup_help.yml
+++ b/.github/ISSUE_TEMPLATE/setup_help.yml
@@ -1,0 +1,51 @@
+name: Setup help
+description: Ask for help getting OpenGUI running.
+title: ""
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this when the server, Android app, device connection, or model setup is blocked.
+
+        Please do not paste API keys, bot tokens, private screenshots, or full `.env` files.
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to run?
+      description: Tell us which setup path you are following.
+      placeholder: I am trying to start the backend and connect an Android emulator.
+    validations:
+      required: true
+  - type: textarea
+    id: blocked
+    attributes:
+      label: Where did it stop?
+      description: Paste the command, error, or screen where you got stuck.
+      placeholder: |
+        cd server && ./start.sh
+        ...
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Fill in what you know. It is okay to leave unknown fields blank.
+      value: |
+        - OS:
+        - Node.js:
+        - pnpm:
+        - Docker:
+        - Android Studio or Gradle:
+        - Android device or emulator:
+    validations:
+      required: false
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      description: List any docs, commands, or workarounds you already tried.
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Add lightweight GitHub issue templates for bug reports, feature requests, and setup help.
- Keep blank issues enabled while routing security reports to the private security policy.
- Ask for practical reproduction/setup details without adding heavy contributor process.

## Verification
- `ruby -e 'require "yaml"; files = Dir[".github/ISSUE_TEMPLATE/*.yml"].sort; abort "missing files" unless files.size == 4; files.each { |p| YAML.load_file(p); puts "ok #{p}" }'`
- `git diff --check`

Closes #19
