### PR TITLE
docs: add English and Japanese remote control guides

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -69,7 +69,7 @@ pnpm opengui -- do "Observe the current Android screen and summarize what you se
 
 ## 最近の更新
 
-- `[2026.5.16]` [Codex / Claude Code リモートコントロール](./docs/codex-remote-control.zh-CN.md)を追加しました。ローカル REST API、`pnpm opengui -- ...` CLI、[`open-gui-remote-control`](./skills/open-gui-remote-control/SKILL.md) Skill により、コーディングエージェントから Android アプリタスクをディスパッチできます。
+- `[2026.5.16]` [Codex / Claude Code リモートコントロール](./docs/codex-remote-control.ja-JP.md)を追加しました。ローカル REST API、`pnpm opengui -- ...` CLI、[`open-gui-remote-control`](./skills/open-gui-remote-control/SKILL.md) Skill により、コーディングエージェントから Android アプリタスクをディスパッチできます。
 - `[2026.5.9]` [Discord IM エントリー](./docs/DISCORD.ja-JP.md)を追加しました。プレフィックスコマンド、スラッシュコマンド、allowlist、guild 単位のコマンド登録に対応し、Discord チャンネルから Android タスクをリモート実行できます。
 - `[2026.5.7]` Docker ベースのバックエンド起動時に、一般的な PostgreSQL / Redis ポート競合を避けられるようローカル起動フローを強化しました。
 - `[2026.5.1]` バックエンドのオンボーディングとして、`.env.example`、起動時チェック、graph agent 向け VLM 環境変数設定を整備しました。

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Manual setup guide: [`docs/get-started.md`](./docs/get-started.md).
 
 ## Recent Updates
 
-- `[2026.5.16]` Added [Codex / Claude Code remote control](./docs/codex-remote-control.zh-CN.md) with a local REST API, `pnpm opengui -- ...` CLI, and the [`open-gui-remote-control`](./skills/open-gui-remote-control/SKILL.md) Skill for dispatching Android app tasks from coding agents.
+- `[2026.5.16]` Added [Codex / Claude Code remote control](./docs/codex-remote-control.md) with a local REST API, `pnpm opengui -- ...` CLI, and the [`open-gui-remote-control`](./skills/open-gui-remote-control/SKILL.md) Skill for dispatching Android app tasks from coding agents.
 - `[2026.5.9]` Added a [Discord IM channel](./docs/DISCORD.md) for remote Android task dispatch, including prefix commands, slash commands, allowlists, and guild-scoped command registration.
 - `[2026.5.7]` Hardened local startup to avoid common PostgreSQL and Redis port conflicts during Docker-based backend setup.
 - `[2026.5.1]` Improved backend onboarding with `.env.example`, startup checks, and graph-agent VLM environment configuration.

--- a/docs/codex-remote-control-promo.zh-CN.md
+++ b/docs/codex-remote-control-promo.zh-CN.md
@@ -21,4 +21,4 @@
 读一下 ./skills/open-gui-bootstrap/SKILL.md，然后帮我把 OpenGUI 跑起来，只在必须时告诉我手机上要做什么。
 ```
 
-技术细节：[codex-remote-control.zh-CN.md](./docs/codex-remote-control.zh-CN.md)
+技术细节：[codex-remote-control.zh-CN.md](./codex-remote-control.zh-CN.md)

--- a/docs/codex-remote-control.ja-JP.md
+++ b/docs/codex-remote-control.ja-JP.md
@@ -1,0 +1,124 @@
+<p align="center">
+  <strong>言語:</strong> <a href="./codex-remote-control.md">English</a> | <a href="./codex-remote-control.zh-CN.md">简体中文</a> | <a href="./codex-remote-control.ja-JP.md">日本語</a>
+</p>
+
+# Codex で Android スマートフォンを操作する
+
+OpenGUI を使うと、Codex または Claude Code から自然言語のタスクを実機の Android スマートフォンへ渡せます。コーディングエージェントが座標を直接クリックしたり、Android の socket プロトコルを直接処理したりするわけではありません。OpenGUI バックエンドを通じてタスクを作成し、バックエンドがオンラインの Android クライアントへ execution をディスパッチします。
+
+## 全体のフロー
+
+Codex または Claude Code がコマンドの入口になります。OpenGUI バックエンドは task と execution の状態を保存し、Android クライアントはスクリーンショットの取得、アクションの実行、端末状態の返送を担当します。タスクはバックエンドに入った後、standby 接続を通じてオンライン端末へ送られ、execution socket のループで実行されます。
+
+```mermaid
+flowchart LR
+  U["Developer"] --> A["Codex / Claude Code"]
+  A --> S["open-gui-remote-control Skill"]
+  S --> CLI["server CLI<br/>pnpm opengui -- ... --json"]
+  CLI --> BE["OpenGUI backend<br/>Task / Execution"]
+  BE --> ST["Standby dispatch"]
+  ST --> AC["Android client"]
+  AC --> EX["Execution socket"]
+  EX --> VLM["Screenshot + VLM"]
+  VLM --> ACT["Accessibility action"]
+  ACT --> AC
+```
+
+`task` は実行内容を定義します。`execution` は task の具体的な1回の実行です。1つの task は複数回実行でき、実行ごとに新しい `executionId` が発行されます。`do` コマンドは task を作成してすぐに execution を開始します。`run <taskId>` は既存の task から新しい execution を開始します。`status <executionId>` は特定の実行状態を取得します。
+
+## Skill の役割
+
+OpenGUI の起動には `open-gui-bootstrap` を使用します。リポジトリの確認、依存関係のインストール、バックエンドの起動、Android クライアントのビルドとインストール、`adb reverse`、モデル設定を担当します。
+
+すでに OpenGUI へ接続されているスマートフォンの操作には `open-gui-remote-control` を使用します。端末の検出、task の作成と実行、状態確認、一時停止、再開、キャンセルを担当します。
+
+何もセットアップされていない環境では、最初に bootstrap を実行してください。バックエンドが起動し、Android クライアントがインストール済みでオンラインになった後は、remote control を直接使用できます。
+
+## 実行環境
+
+ローカルでスマートフォンを操作する場合は、Android 端末を接続した開発マシン上で実行してください。この環境には Node.js 22、pnpm、Docker、Java、adb、および実行可能な OpenGUI リポジトリが必要です。
+
+```text
+https://github.com/Core-Mate/OpenGUI
+```
+
+実行可能なリポジトリには次のファイルが含まれます。
+
+```text
+server/package.json
+client/start.sh
+```
+
+Android 側で USB デバッグを許可し、OpenGUI の Accessibility Service とオーバーレイ権限を有効にしてください。USB 接続した端末からローカルバックエンドを利用する場合は、リバースポートフォワーディングを設定します。
+
+```bash
+adb reverse tcp:7777 tcp:7777
+```
+
+バックエンドのデフォルト URL は次のとおりです。
+
+```text
+http://localhost:7777
+```
+
+Android クライアントが standby 接続を安定して維持するには、先にバックエンドへアクセスできる必要があります。クライアントがすでにインストールされている場合は、アプリを開いた状態にしてください。再ビルドは不要です。
+
+リモートバックエンドは、端末ブリッジがすでに設定されている場合にのみ使用してください。通常の USB 端末では、USB デバッグ、APK のインストール、`adb reverse` が端末を物理的に接続したマシン上で行われるため、バックエンドを暗黙的にリモートへ配置しないでください。
+
+## 使用方法
+
+OpenGUI がすでに起動している場合は、次のプロンプトを Codex または Claude Code に渡します。
+
+```text
+Read ./skills/open-gui-remote-control/SKILL.md and use OpenGUI to control my Android phone.
+Task: 現在の Android 画面を確認し、表示内容を簡潔に説明してから終了してください。
+Only ask me for phone-side permissions or missing secrets.
+```
+
+OpenGUI がまだ起動していない場合は、最初に bootstrap を実行してから remote control を使用します。
+
+```text
+Read ./skills/open-gui-bootstrap/SKILL.md first to start OpenGUI.
+Then read ./skills/open-gui-remote-control/SKILL.md and run this phone task:
+現在の Android 画面を確認し、表示内容を簡潔に説明してから終了してください。
+```
+
+Skill はリポジトリ内の CLI を優先して使用します。対応するローカルコマンドは次のとおりです。
+
+```bash
+cd server
+pnpm opengui -- devices --json
+pnpm opengui -- do "現在の Android 画面を確認し、表示内容を簡潔に説明してから終了してください" --json
+pnpm opengui -- status <executionId> --json
+```
+
+複数の端末がオンラインの場合は、最初に一覧を取得し、対象端末を指定します。
+
+```bash
+pnpm opengui -- devices --json
+pnpm opengui -- do "設定を開き、現在のネットワーク状態を確認してください" --device <deviceId> --json
+```
+
+バックエンドがデフォルト以外のアドレスで動作している場合は、base URL を明示します。
+
+```bash
+pnpm opengui -- devices --base-url <url> --json
+```
+
+`--json` を使うと、Codex または Claude Code が `deviceId`、`taskId`、`executionId`、execution 状態を解析できる構造化データが返されます。
+
+## 実行モデル
+
+OpenGUI は固定座標のスクリプトを使用しません。`adb shell input tap` は固定座標をクリックできますが、現在の画面内容やタスクの進行状況を理解できません。権限ダイアログ、ログイン画面、ネットワーク読み込み、レコメンドのオーバーレイ、システム割り込みなどによって、座標だけのスクリプトは簡単に失敗します。
+
+OpenGUI の execution 状態はバックエンドに保存されます。Android クライアントがスクリーンショットと端末状態をアップロードし、VLM が画面を理解して次のアクションを選択し、Android AccessibilityService がそのアクションを実行します。Codex または Claude Code は CLI または REST API を通じて execution を監視・制御するだけです。
+
+## トラブルシューティング
+
+リポジトリのパスが正しくない場合は、現在のディレクトリまたはその子ディレクトリに `server/package.json` と `client/start.sh` があるか確認してください。存在しない場合は、`https://github.com/Core-Mate/OpenGUI` から実行可能なリポジトリを取得してください。
+
+`devices` が空の一覧を返す場合は、バックエンドが起動していること、Android 上で OpenGUI アプリが開いていること、USB デバッグが承認されていること、`adb reverse tcp:7777 tcp:7777` が設定されていること、Accessibility Service とオーバーレイ権限が有効になっていることを確認してください。
+
+CLI が `fetch failed` を返す場合は、最初に `http://localhost:7777/docs` を開いてください。バックエンドが別のアドレスで動作している場合は、`--base-url <url>` で指定します。
+
+リモートバックエンドは、デフォルトではローカルの USB 端末を操作できません。USB と `adb reverse` で接続した端末は、ローカル開発マシン上のバックエンドへ接続します。リモート実行が成立するのは、端末からリモートバックエンドへ到達でき、必要な端末ブリッジがすでに設定されている場合だけです。

--- a/docs/codex-remote-control.md
+++ b/docs/codex-remote-control.md
@@ -1,0 +1,124 @@
+<p align="center">
+  <strong>Language:</strong> <a href="./codex-remote-control.md">English</a> | <a href="./codex-remote-control.zh-CN.md">简体中文</a> | <a href="./codex-remote-control.ja-JP.md">日本語</a>
+</p>
+
+# Control an Android Phone with Codex
+
+OpenGUI lets Codex or Claude Code hand natural-language tasks to a real Android phone. The coding agent does not click raw coordinates or handle the Android socket protocol directly. It creates tasks through the OpenGUI backend, which dispatches each execution to an online Android client.
+
+## End-to-End Flow
+
+Codex or Claude Code is the command entry point. The OpenGUI backend stores task and execution state, while the Android client captures screenshots, performs actions, and reports device state. A task enters the backend, is dispatched through the standby connection, and then runs through the execution socket loop.
+
+```mermaid
+flowchart LR
+  U["Developer"] --> A["Codex / Claude Code"]
+  A --> S["open-gui-remote-control Skill"]
+  S --> CLI["server CLI<br/>pnpm opengui -- ... --json"]
+  CLI --> BE["OpenGUI backend<br/>Task / Execution"]
+  BE --> ST["Standby dispatch"]
+  ST --> AC["Android client"]
+  AC --> EX["Execution socket"]
+  EX --> VLM["Screenshot + VLM"]
+  VLM --> ACT["Accessibility action"]
+  ACT --> AC
+```
+
+A `task` defines what should be done. An `execution` is one concrete run of that task. A task can run multiple times, and every run receives a new `executionId`. The `do` command creates a task and immediately starts an execution. `run <taskId>` starts a new execution for an existing task. `status <executionId>` reads the status of a specific run.
+
+## Skill Responsibilities
+
+Use `open-gui-bootstrap` to start OpenGUI. It checks the repository, installs dependencies, starts the backend, builds and installs the Android client, configures `adb reverse`, and handles model configuration.
+
+Use `open-gui-remote-control` to control a phone that is already connected to OpenGUI. It handles device discovery, task creation and execution, status checks, pause, resume, and cancel operations.
+
+From a clean environment, run bootstrap first. When the backend is running and the Android client is installed and online, use remote control directly.
+
+## Runtime Environment
+
+Local phone control should run on the development machine connected to the Android device. The machine needs Node.js 22, pnpm, Docker, Java, and adb, together with a runnable OpenGUI checkout:
+
+```text
+https://github.com/Core-Mate/OpenGUI
+```
+
+The checkout must contain:
+
+```text
+server/package.json
+client/start.sh
+```
+
+Approve USB debugging on Android, then enable the OpenGUI Accessibility Service and overlay permission. When a USB-connected phone uses the local backend, configure reverse port forwarding:
+
+```bash
+adb reverse tcp:7777 tcp:7777
+```
+
+The default backend URL is:
+
+```text
+http://localhost:7777
+```
+
+The backend must be reachable before the Android client can maintain its standby connection. If the client is already installed, keep the app open; rebuilding it is not required.
+
+A remote backend is appropriate only when a device bridge is already configured. A regular USB phone should not silently be paired with a remote backend because USB debugging, APK installation, and `adb reverse` happen on the machine physically connected to the phone.
+
+## Usage
+
+When OpenGUI is already running, give Codex or Claude Code this prompt:
+
+```text
+Read ./skills/open-gui-remote-control/SKILL.md and use OpenGUI to control my Android phone.
+Task: Observe the current Android screen, briefly describe what you see, and then finish.
+Only ask me for phone-side permissions or missing secrets.
+```
+
+If OpenGUI is not running yet, bootstrap it before entering remote control:
+
+```text
+Read ./skills/open-gui-bootstrap/SKILL.md first to start OpenGUI.
+Then read ./skills/open-gui-remote-control/SKILL.md and run this phone task:
+Observe the current Android screen, briefly describe what you see, and then finish.
+```
+
+The Skill uses the repository CLI first. The equivalent local commands are:
+
+```bash
+cd server
+pnpm opengui -- devices --json
+pnpm opengui -- do "Observe the current Android screen, briefly describe what you see, and then finish" --json
+pnpm opengui -- status <executionId> --json
+```
+
+When multiple devices are online, list them first and target a specific device:
+
+```bash
+pnpm opengui -- devices --json
+pnpm opengui -- do "Open Settings and check the current network status" --device <deviceId> --json
+```
+
+Specify the base URL when the backend does not use the default address:
+
+```bash
+pnpm opengui -- devices --base-url <url> --json
+```
+
+Use `--json` to return structured data that Codex or Claude Code can parse for `deviceId`, `taskId`, `executionId`, and execution status.
+
+## Execution Model
+
+OpenGUI does not use fixed coordinate scripts. `adb shell input tap` can click a static coordinate, but it cannot understand the current screen or know how far a task has progressed. Permission dialogs, login pages, network loading, recommendation overlays, and system interruptions can all break a coordinate-only script.
+
+OpenGUI stores execution state in the backend. The Android client uploads screenshots and device state, the VLM interprets the screen and selects the next action, and Android AccessibilityService performs that action. Codex or Claude Code only needs to monitor and control the execution through the CLI or REST API.
+
+## Troubleshooting
+
+If the repository path is wrong, check whether the current directory or one of its child directories contains `server/package.json` and `client/start.sh`. If not, obtain the runnable repository from `https://github.com/Core-Mate/OpenGUI`.
+
+If `devices` returns an empty list, check that the backend is running, the OpenGUI Android app is open, USB debugging is approved, `adb reverse tcp:7777 tcp:7777` has been applied, and Accessibility Service and overlay permissions are enabled.
+
+If the CLI reports `fetch failed`, first open `http://localhost:7777/docs`. If the backend uses another address, pass it with `--base-url <url>`.
+
+A remote backend cannot control a local USB phone by default. A phone connected through USB and `adb reverse` reaches the backend on its local development machine. Remote operation works only when the phone can reach the remote backend and the required device bridge has already been configured.

--- a/docs/codex-remote-control.zh-CN.md
+++ b/docs/codex-remote-control.zh-CN.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <strong>语言切换：</strong><a href="./codex-remote-control.md">English</a> | <a href="./codex-remote-control.zh-CN.md">简体中文</a> | <a href="./codex-remote-control.ja-JP.md">日本語</a>
+</p>
+
 # 用 Codex 控制 Android 手机
 
 OpenGUI 让 Codex / Claude Code 可以把自然语言任务交给一台真实 Android 手机执行。Codex 不直接点坐标，也不直接处理 Android socket 协议；它通过 OpenGUI 后端创建任务，后端再把执行请求交给在线的 Android client。
@@ -35,7 +39,7 @@ flowchart LR
 本地手机控制应运行在连接 Android 手机的开发机上。这个环境需要能运行 Node.js 22、pnpm、Docker、Java 和 adb，并且已经拿到 OpenGUI 仓库：
 
 ```text
-https://github.com/Core-Mate/open-gui
+https://github.com/Core-Mate/OpenGUI
 ```
 
 可运行的 OpenGUI 仓库包含：
@@ -111,7 +115,7 @@ OpenGUI 的执行状态保存在后端。Android client 上传截图和设备状
 
 ## 故障处理
 
-仓库路径不对时，检查当前目录或子目录是否存在 `server/package.json` 和 `client/start.sh`。如果不存在，使用 `https://github.com/Core-Mate/open-gui` 获取可运行仓库。
+仓库路径不对时，检查当前目录或子目录是否存在 `server/package.json` 和 `client/start.sh`。如果不存在，使用 `https://github.com/Core-Mate/OpenGUI` 获取可运行仓库。
 
 `devices` 返回空时，检查 Android client 是否连上 backend：backend 是否运行，手机是否打开 OpenGUI App，USB debugging 是否授权，`adb reverse tcp:7777 tcp:7777` 是否执行，Accessibility Service 和悬浮窗权限是否开启。
 

--- a/skills/open-gui-remote-control/SKILL.md
+++ b/skills/open-gui-remote-control/SKILL.md
@@ -49,7 +49,7 @@ If the user asks to install or bootstrap OpenGUI from scratch, use `open-gui-boo
 OpenGUI's runnable source checkout is:
 
 ```text
-https://github.com/Core-Mate/open-gui
+https://github.com/Core-Mate/OpenGUI
 ```
 
 The checkout must contain both:
@@ -91,8 +91,8 @@ find . -maxdepth 3 -type f -path '*/client/start.sh' -print
 If no runnable checkout exists and the user wants the agent to set it up locally, clone the public repository:
 
 ```bash
-git clone https://github.com/Core-Mate/open-gui.git
-cd open-gui
+git clone https://github.com/Core-Mate/OpenGUI.git
+cd OpenGUI
 ```
 
 If the destination already exists, do not overwrite it. Enter the existing directory, inspect `git status`, and pull only when the user asked for the latest code or when the checkout is clean enough to update safely.
@@ -181,7 +181,7 @@ Base URL priority:
 
 ### 1. Obtain the runnable checkout
 
-Find or clone `https://github.com/Core-Mate/open-gui`.
+Find or clone `https://github.com/Core-Mate/OpenGUI`.
 
 Then work from the repository root that contains both:
 


### PR DESCRIPTION
## Summary

- add English and Japanese Codex / Claude Code remote-control guides
- add language navigation across the English, Chinese, and Japanese guides
- update English and Japanese README links to their matching localized guides
- normalize the canonical repository URL in the remote-control skill
- fix the broken relative link in the Chinese promo document

## Validation

- `git diff --cached --check`
- verified that all modified local Markdown links resolve
- verified that CLI commands and parameters remain aligned across all three guides

Fixes #50