### PR TITLE
docs: surface execution cancellation guidance

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -65,6 +65,12 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 ```
 
+タスクのレスポンスには `executionId` が含まれます。実行中のタスクを停止できるように、この値を控えておいてください：
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 手動セットアップガイド: [`docs/get-started.md`](./docs/get-started.md)
 
 ## 最近の更新
@@ -168,6 +174,7 @@ cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 pnpm opengui -- status <executionId> --json
+pnpm opengui -- cancel <executionId> --json
 ```
 
 推奨プロファイル:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 ```
 
+The task response includes an `executionId`. Keep it so you can stop the active task:
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 Manual setup guide: [`docs/get-started.md`](./docs/get-started.md).
 
 ## Recent Updates
@@ -171,6 +177,7 @@ cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 pnpm opengui -- status <executionId> --json
+pnpm opengui -- cancel <executionId> --json
 ```
 
 Recommended profiles:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,6 +65,12 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，然后结束" --json
 ```
 
+任务响应中会返回 `executionId`。请保留它，以便停止正在执行的任务：
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 手动安装指南：[`docs/get-started.md`](./docs/get-started.md)。
 
 ## 近期更新
@@ -169,6 +175,7 @@ cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，然后结束" --json
 pnpm opengui -- status <executionId> --json
+pnpm opengui -- cancel <executionId> --json
 ```
 
 推荐配置：

--- a/docs/codex-remote-control.ja-JP.md
+++ b/docs/codex-remote-control.ja-JP.md
@@ -92,6 +92,12 @@ pnpm opengui -- do "現在の Android 画面を確認し、表示内容を簡潔
 pnpm opengui -- status <executionId> --json
 ```
 
+`do` のレスポンスには `executionId` が含まれます。実行中のタスクを停止できるように、この値を控えておいてください：
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 複数の端末がオンラインの場合は、最初に一覧を取得し、対象端末を指定します。
 
 ```bash

--- a/docs/codex-remote-control.md
+++ b/docs/codex-remote-control.md
@@ -92,6 +92,12 @@ pnpm opengui -- do "Observe the current Android screen, briefly describe what yo
 pnpm opengui -- status <executionId> --json
 ```
 
+The `do` response includes an `executionId`. Keep it so you can stop the active task:
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 When multiple devices are online, list them first and target a specific device:
 
 ```bash

--- a/docs/codex-remote-control.zh-CN.md
+++ b/docs/codex-remote-control.zh-CN.md
@@ -92,6 +92,12 @@ pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，
 pnpm opengui -- status <executionId> --json
 ```
 
+`do` 的响应中会返回 `executionId`。请保留它，以便停止正在执行的任务：
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 多台设备在线时，先读取设备列表，再指定目标设备：
 
 ```bash

--- a/skills/open-gui-remote-control/SKILL.md
+++ b/skills/open-gui-remote-control/SKILL.md
@@ -258,6 +258,12 @@ pnpm opengui -- run <taskId> --device <deviceId> --json
 
 Capture `executionId` from the response.
 
+Before continuing, make sure the user knows that the active execution can be stopped with:
+
+```bash
+pnpm opengui -- cancel <executionId> --json
+```
+
 ### 6. Poll status
 
 Poll until the execution reaches a terminal state:


### PR DESCRIPTION
## Summary

- place the `cancel` command next to the first task example
- explain that task responses return the required `executionId`
- keep English, Simplified Chinese, and Japanese guidance aligned
- surface the stop path earlier in the remote-control skill workflow

## Validation

- `git diff --check`
- documentation-only change; no runtime behavior changed

Fixes #55