### PR TITLE
fix: require Android 11 for screenshot execution

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -40,7 +40,7 @@ Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me f
 
 必要なもの:
 
-- Android スマートフォンまたはエミュレーター
+- Android 11（API 30）以降のスマートフォンまたはエミュレーター
 - USB デバッグの有効化
 - AccessibilityService の有効化
 - 実際のタスク実行に使うモデル API キー
@@ -131,7 +131,7 @@ OpenGUI は、明示的なオーケストレーションレイヤーを持つモ
 
 ## 現在の制限
 
-- Android 実機またはエミュレーターが必要です。
+- Android 11（API 30）以降の実機またはエミュレーターが必要です。
 - USB デバッグと AccessibilityService 権限が必要です。
 - 実行品質は、モデル、アプリ UI、ネットワーク状態、タスクの長さに依存します。
 - 現時点では OS レベルの常駐アシスタントではありません。タスクは手動、または設定済みのディスパッチ経路から起動します。

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me f
 
 You will need:
 
-- an Android phone or emulator
+- an Android 11 (API 30) or newer phone or emulator
 - USB debugging enabled
 - AccessibilityService enabled
 - model API keys for real task execution
@@ -134,7 +134,7 @@ The source code currently exposes these pieces:
 
 ## Current Limitations
 
-- Requires an Android device or emulator.
+- Requires an Android 11 (API 30) or newer device or emulator.
 - Requires USB debugging and AccessibilityService permissions.
 - Execution quality depends on the model, app UI, network state, and task length.
 - Not an always-on OS-level assistant yet; tasks are currently triggered manually or through configured dispatch channels.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,7 +40,7 @@ Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me f
 
 你需要准备：
 
-- 一台 Android 手机或模拟器
+- 一台 Android 11（API 30）或更高版本的手机或模拟器
 - 已开启 USB 调试
 - 已开启 AccessibilityService
 - 用于真实任务执行的模型 API Key
@@ -132,7 +132,7 @@ OpenGUI 采用的是一套分层清晰的移动 operator system。
 
 ## 当前限制
 
-- 需要 Android 真机或模拟器。
+- 需要 Android 11（API 30）或更高版本的真机或模拟器。
 - 需要开启 USB 调试和 AccessibilityService 权限。
 - 执行质量会受到模型能力、App UI、网络状态和任务长度影响。
 - 目前还不是 OS 级常驻助手；任务需要手动触发，或通过已配置的派发入口触发。

--- a/client/app/build.gradle.kts
+++ b/client/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "com.coremate.opengui"
-        minSdk = 24
+        minSdk = 30
         targetSdk = 35
         versionCode = 1000031701
         versionName = "1.0.0317.01"

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -66,6 +66,10 @@ Useful endpoints after startup:
 
 ### 2. Connect a device and install the Android client
 
+The current Android client requires Android 11 (API 30) or newer. Android 9
+(API 28) and other older releases are not supported by the screenshot-based
+execution path. The client currently targets Android 15 (API 35).
+
 ```bash
 cd client
 ./start.sh

--- a/skills/open-gui-bootstrap/SKILL.md
+++ b/skills/open-gui-bootstrap/SKILL.md
@@ -158,6 +158,7 @@ Expected behavior:
 
 - checks `adb` and Java
 - verifies a device is connected
+- installs only on Android 11 (API 30) or newer, matching the app's minimum SDK
 - runs `adb reverse tcp:7777 tcp:7777`
 - builds the debug APK
 - installs it


### PR DESCRIPTION
## What changed?

- raised the Android application minimum SDK from 24 to 30
- documented Android 11 (API 30) as the minimum supported version
- kept the English, Simplified Chinese, and Japanese README requirements aligned
- updated the getting-started guide and bootstrap skill

## Why?

The current screenshot execution path uses `AccessibilityService.takeScreenshot()` and explicitly returns no screenshot below API 30. Keeping `minSdk 24` allowed Android 7–10 devices to install the APK even though core GUI-agent execution could not run.

## Testing

- `./gradlew assembleDebug` — successful (194 tasks)
- inspected the generated APK with `aapt dump badging`
  - `sdkVersion: 30`
  - `targetSdkVersion: 35`
- `git diff --check`

## Device verification

Not run — no Android 15 device or emulator was connected. This change only adjusts the installation floor; the Android 11+ runtime execution code and backend protocol are unchanged.

## Notes

Fixes #53