### PR TITLE
docs: clarify minimal first-run environment

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -38,15 +38,16 @@ What `server/start.sh` does:
 - pushes schema and seeds default backend data
 - starts the backend on port `7777`
 
-Required keys for a practical first run:
+For the default first-run setup, add only your model API key:
 
 - `VLM_API_KEY`
-- `VLM_BASE_URL`
-- `VLM_MODEL`
 
 The backend currently uses the `VLM_*` variables as the shared
 OpenAI-compatible model configuration for graph agents. They are used by
 planning, supervision, summarization, and the executor vision path.
+
+`VLM_BASE_URL` and `VLM_MODEL` already have defaults in `.env.example`. Change
+them only when using a different OpenAI-compatible provider or model.
 
 Example:
 
@@ -56,8 +57,9 @@ VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
 VLM_MODEL=qwen3.6-plus
 ```
 
-The backend can start without these values, but real task execution will fail
-when the graph needs to call the model.
+The backend can start without `VLM_API_KEY`, but real task execution will fail
+when the graph needs to call the model. LangSmith tracing and IM channel
+credentials are optional for the first run.
 
 Useful endpoints after startup:
 

--- a/server/apps/backend/.env.example
+++ b/server/apps/backend/.env.example
@@ -1,5 +1,9 @@
 # OpenGUI Server Environment Configuration
 # Copy this file to .env and fill in your values
+# For the default first-run setup, only VLM_API_KEY needs to be filled in.
+# VLM_BASE_URL and VLM_MODEL already have defaults below. Change them only
+# when using a different OpenAI-compatible provider or model.
+# LangSmith tracing and IM channel settings are optional.
 
 # App
 NODE_ENV=development
@@ -16,7 +20,7 @@ REDIS_PASSWORD=
 
 # Graph agent model config (OpenAI-compatible)
 # Used by planner, supervisor, summarizer, and executor VLM calls.
-# VLM_API_KEY is required before tasks can execute successfully.
+# VLM_API_KEY is the only value that must be added for the default setup.
 # VLM_BASE_URL can point to any OpenAI-compatible endpoint.
 VLM_API_KEY=
 VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1

--- a/server/apps/backend/README.md
+++ b/server/apps/backend/README.md
@@ -36,7 +36,7 @@ pnpm start:prod
 cp .env.example .env
 ```
 
-基础运行至少需要 PostgreSQL、Redis 和模型配置。未配置 IM 机器人时，后端会正常启动，只跳过对应入口。
+基础运行至少需要 PostgreSQL、Redis 和模型配置。使用 `.env.example` 中的默认模型地址和模型名时，只需填写 `VLM_API_KEY`。未配置 IM 机器人时，后端会正常启动，只跳过对应入口。
 
 ### Graph Agent 模型配置
 
@@ -53,9 +53,10 @@ VLM_MODEL=qwen3.6-plus
 说明：
 
 - `VLM_API_KEY`：模型服务 API key，执行真实任务前必须配置。
-- `VLM_BASE_URL`：OpenAI-compatible endpoint。使用 OpenAI 默认接口时可以按实际 provider 配置。
-- `VLM_MODEL`：模型名，例如 `qwen3.6-plus` 或你的 provider 支持的其他模型。
-- 后端可以在缺少这些值时启动，但任务执行到模型调用时会失败。
+- `VLM_BASE_URL`：OpenAI-compatible endpoint，示例文件已提供默认值；更换 provider 时再修改。
+- `VLM_MODEL`：模型名，示例文件已提供默认值 `qwen3.6-plus`；更换模型时再修改。
+- 后端可以在缺少 `VLM_API_KEY` 时启动，但任务执行到模型调用时会失败。
+- LangSmith tracing 和 IM 机器人配置均为可选项，不影响首次本地启动。
 
 ### Discord 入口
 

--- a/server/start.sh
+++ b/server/start.sh
@@ -100,9 +100,10 @@ ENV_EXAMPLE=apps/backend/.env.example
 if [ ! -f "$ENV_FILE" ]; then
   if [ -f "$ENV_EXAMPLE" ]; then
     cp "$ENV_EXAMPLE" "$ENV_FILE"
-    warn ".env was created from .env.example. Please edit it and add your API keys:"
+    warn ".env was created from .env.example. Please edit it and add your model API key:"
     warn "  File: $ENV_FILE"
-    warn "  VLM_API_KEY, VLM_BASE_URL, VLM_MODEL"
+    warn "  VLM_API_KEY"
+    warn "The default VLM_BASE_URL and VLM_MODEL are ready to use. Change them only if you use another provider or model."
     warn "Run this script again after editing the file."
     exit 0
   else

--- a/skills/open-gui-bootstrap/SKILL.md
+++ b/skills/open-gui-bootstrap/SKILL.md
@@ -114,16 +114,18 @@ Expected behavior:
 - pushes schema and seeds data
 - starts the backend
 
-If the first run exits after creating `.env`, ask only for the keys still missing. The default practical keys are:
+If the first run exits after creating `.env`, ask only for the values still missing. With the repository defaults, ask for:
 
-- `CLAUDE_API_KEY`
 - `VLM_API_KEY`
 
-Optional keys include:
+`VLM_BASE_URL` and `VLM_MODEL` already have defaults. Ask for replacements only when the user chooses another OpenAI-compatible provider or model.
 
-- `ANTHROPIC_API_KEY` for creator-agent flows
+Optional configuration includes:
+
+- LangSmith tracing variables
 - `FEISHU_APP_ID` / `FEISHU_APP_SECRET`
 - `TELEGRAM_BOT_TOKEN`
+- Discord bot variables
 
 ### 4. Route model providers
 
@@ -198,5 +200,5 @@ Keep updates short and operational.
 
 Good:
 
-- "The backend script created `.env` and stopped. I need `CLAUDE_API_KEY` and `VLM_API_KEY` to continue."
+- "The backend script created `.env` and stopped. Add `VLM_API_KEY` to continue with the default model settings."
 - "The APK is built. Connect the phone by USB and tap Allow on the debugging dialog. I will install it after that."


### PR DESCRIPTION
## What changed?

- added a minimal first-run note near the top of the backend environment example
- clarified that the default setup only requires users to add `VLM_API_KEY`
- explained when `VLM_BASE_URL` and `VLM_MODEL` need to be changed
- aligned the startup script, getting-started guide, backend README, and bootstrap skill

## Why?

The existing first-run guidance made all three `VLM_*` values look user-required, even though the repository already provides defaults for the endpoint and model. This gives new users a smaller, clearer setup path while preserving custom-provider configuration.

## Testing

- `git diff --check`
- `bash -n server/start.sh`
- validated `skills/open-gui-bootstrap` with the skill validator
- checked the repository for stale first-run multi-key guidance

## Device verification

Not applicable — this changes setup guidance and first-run messaging only.

## Notes

Fixes #48
