### PR TITLE
docs: add OpenCode usage guidance

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="#deepseek-harnessでopenguiを使う"><img src="https://img.shields.io/badge/INSTALL-DEEPSEEK_HARNESS_PLUGIN-6f42c1?style=for-the-badge" alt="DeepSeek Harnessプラグインをインストール"></a>
-  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_CLAUDE_OR_CODEX-ffb000?style=for-the-badge" alt="Claude または Codex でブートストラップ"></a>
+  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_AI_AGENTS-ffb000?style=for-the-badge" alt="Claude Code、Codex、OpenCode でブートストラップ"></a>
   <img src="https://img.shields.io/badge/SYSTEM-MULTI_ROLE_OPERATOR-1f6feb?style=for-the-badge" alt="マルチロールオペレーターシステム">
   <img src="https://img.shields.io/badge/TASKS-UP_TO_12_HOURS-cf222e?style=for-the-badge" alt="最大12時間のタスク">
   <img src="https://img.shields.io/badge/MODELS-CLAUDE_OPUS_|_QWEN_|_DOUBAO_|_BYO_API-2f9e44?style=for-the-badge" alt="推奨モデルプロファイル">
@@ -73,11 +73,13 @@ GUI操作向けの現在の推奨順：
 
 ## OpenGUIスタック一式を実行する
 
-OpenGUIのバックエンドとAndroidクライアント一式を実行する場合は、Claude CodeまたはCodexにブートストラップを任せることができます。
+OpenGUIのバックエンドとAndroidクライアント一式を実行する場合は、Claude Code、Codex、またはOpenCodeにブートストラップを任せることができます。
 
 ```text
 Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
 ```
+
+Skill のパスを明示したこのプロンプトは OpenCode でも使用できます。このリポジトリでは Skill をトップレベルの `skills/` に配置しているため、OpenCode では自動検出に頼らず、上記のようにパスを指定してください。OpenCode が標準で検出する `.opencode/skills/` と `.agents/skills/` については、[Agent Skills ドキュメント](https://opencode.ai/docs/skills/)を参照してください。
 
 必要なもの:
 
@@ -129,8 +131,8 @@ OpenGUI は、AI が実際の Android スマートフォンを操作できるよ
 
 - **主要な Android アプリを操作**: X、Reddit、Hacker News、Telegram、WeChat、Weibo、小紅書などの Android アプリ上で、AI にモバイルタスクを実行させることができます。
 - **組み込みワークフローを実行**: バックエンド、Android クライアント、スタンバイディスパッチパス、組み込みタスク機能一式がすぐに実行可能な状態で含まれています。
-- **Claude や Codex にブートストラップさせる**: [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) をモデルに指示し、目的を自然言語で説明すれば、セットアップ、ビルド、インストール、ローカルデバッグをモデルが処理します。
-- **Codex で Android アプリを操作**: OpenGUI の起動後、[`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) を Codex または Claude Code に渡すと、ローカル CLI 経由でデバイス一覧、タスクディスパッチ、execution 状態確認ができます。
+- **AI コーディングエージェントにブートストラップさせる**: [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) を Claude Code、Codex、または OpenCode に渡し、目的を自然言語で説明すれば、セットアップ、ビルド、インストール、ローカルデバッグをエージェントが処理します。
+- **AI コーディングエージェントで Android アプリを操作**: OpenGUI の起動後、[`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) を Claude Code、Codex、または OpenCode に渡すと、ローカル CLI 経由でデバイス一覧、タスクディスパッチ、execution 状態確認ができます。
 - **リモートワーカーとしてスマートフォンを操作**: Feishu、Telegram、Discord、REST API 経由でタスクをディスパッチし、デバイスをスタンバイ状態に保ち、バックエンドから構造化された結果を受け取ることができます。
 
 ## 特徴
@@ -191,13 +193,13 @@ OpenGUI は、明示的なオーケストレーションレイヤーを持つモ
 
 ## OpenGUI の使い方
 
-### 1. Claude や Codex を使う場合
+### 1. Claude Code、Codex、または OpenCode を使う場合
 
 [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) から始めてください。
 
 手順はシンプルです:
 
-1. Claude または Codex にスキルを指示する
+1. Claude Code、Codex、または OpenCode に Skill を指示する
 2. タスクを自然言語で説明する
 3. バックエンドのブートストラップ、APK ビルド、インストール、ローカルデバッグをモデルに任せる
 
@@ -209,7 +211,7 @@ OpenGUI は、明示的なオーケストレーションレイヤーを持つモ
 - オーバーレイまたはバッテリー権限の付与
 - API キーまたはボット認証情報の入力
 
-バックエンドと Android client が起動したら、[`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) を使って Codex または Claude Code にローカル CLI 経由でスマートフォンを操作させることができます:
+バックエンドと Android client が起動したら、[`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) を使って Claude Code、Codex、または OpenCode にローカル CLI 経由でスマートフォンを操作させることができます:
 
 ```bash
 cd server

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <p align="center">
   <a href="#use-opengui-in-deepseek-harness"><img src="https://img.shields.io/badge/INSTALL-DEEPSEEK_HARNESS_PLUGIN-6f42c1?style=for-the-badge" alt="Install the DeepSeek Harness plugin"></a>
-  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_CLAUDE_OR_CODEX-ffb000?style=for-the-badge" alt="Bootstrap with Claude or Codex"></a>
+  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_AI_AGENTS-ffb000?style=for-the-badge" alt="Bootstrap with Claude Code, Codex, or OpenCode"></a>
   <img src="https://img.shields.io/badge/SYSTEM-MULTI_ROLE_OPERATOR-1f6feb?style=for-the-badge" alt="Multi-role operator system">
   <img src="https://img.shields.io/badge/TASKS-UP_TO_12_HOURS-cf222e?style=for-the-badge" alt="Tasks up to 12 hours">
   <img src="https://img.shields.io/badge/MODELS-CLAUDE_OPUS_|_QWEN_|_DOUBAO_|_BYO_API-2f9e44?style=for-the-badge" alt="Recommended model profiles">
@@ -74,11 +74,16 @@ Model availability, pricing, and policy behavior vary by version and region. Whi
 
 ## Run the Full OpenGUI Stack
 
-To run the full OpenGUI backend and Android client, let Claude Code or Codex bootstrap it for you.
+To run the full OpenGUI backend and Android client, let Claude Code, Codex, or OpenCode bootstrap it for you.
 
 ```text
 Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
 ```
+
+This explicit prompt also works in OpenCode. The repository keeps the Skill in
+`skills/`, so OpenCode users should include the path as shown instead of relying
+on automatic Skill discovery. See the [OpenCode Agent Skills documentation](https://opencode.ai/docs/skills/)
+for its native `.opencode/skills/` and `.agents/skills/` locations.
 
 You will need:
 
@@ -130,8 +135,8 @@ You can use the same repository in four practical ways:
 
 - **Operate mainstream Android apps**: let AI handle mobile tasks inside X, Reddit, Hacker News, Telegram, WeChat, Weibo, Xiaohongshu, and other Android apps on a real phone.
 - **Run shipped workflows**: the repository already includes a runnable backend, Android client, standby dispatch path, and a set of built-in task capabilities.
-- **Let Claude or Codex bootstrap it for you**: point the model at [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md), describe the goal in plain language, and let it handle setup, build, install, and local debugging.
-- **Let Codex control Android apps**: after OpenGUI is running, point Codex or Claude Code at [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) to list devices, dispatch tasks, and track executions through the local CLI.
+- **Let an AI coding agent bootstrap it for you**: point Claude Code, Codex, or OpenCode at [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md), describe the goal in plain language, and let it handle setup, build, install, and local debugging.
+- **Let an AI coding agent control Android apps**: after OpenGUI is running, point Claude Code, Codex, or OpenCode at [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) to list devices, dispatch tasks, and track executions through the local CLI.
 - **Operate phones as remote workers**: dispatch tasks through Feishu, Telegram, Discord, or REST API, keep devices on standby, and get structured results back from the backend.
 
 - [Join the Discord community](https://discord.gg/pqHHw7XgJ3)
@@ -194,13 +199,13 @@ The source code currently exposes these pieces:
 
 ## How to Use OpenGUI
 
-### 1. With Claude or Codex
+### 1. With Claude Code, Codex, or OpenCode
 
 Start with [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md).
 
 The intended flow is simple:
 
-1. point Claude or Codex at the skill
+1. point Claude Code, Codex, or OpenCode at the skill
 2. describe the task in plain language
 3. let the model handle backend bootstrap, APK build, install, and local debugging
 
@@ -212,7 +217,7 @@ It should only stop for:
 - granting overlay or battery permissions
 - providing API keys or bot credentials
 
-After the backend and Android client are running, use [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) to let Codex or Claude Code control the phone through the local CLI:
+After the backend and Android client are running, use [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) to let Claude Code, Codex, or OpenCode control the phone through the local CLI:
 
 ```bash
 cd server

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="#在-deepseek-harness-中使用-opengui"><img src="https://img.shields.io/badge/INSTALL-DEEPSEEK_HARNESS_PLUGIN-6f42c1?style=for-the-badge" alt="安装 DeepSeek Harness 插件"></a>
-  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_CLAUDE_OR_CODEX-ffb000?style=for-the-badge" alt="Bootstrap with Claude or Codex"></a>
+  <a href="./skills/open-gui-bootstrap/SKILL.md"><img src="https://img.shields.io/badge/BOOTSTRAP-WITH_AI_AGENTS-ffb000?style=for-the-badge" alt="使用 Claude Code、Codex 或 OpenCode 启动"></a>
   <img src="https://img.shields.io/badge/SYSTEM-MULTI_ROLE_OPERATOR-1f6feb?style=for-the-badge" alt="Multi-role operator system">
   <img src="https://img.shields.io/badge/TASKS-UP_TO_12_HOURS-cf222e?style=for-the-badge" alt="Tasks up to 12 hours">
   <img src="https://img.shields.io/badge/MODELS-CLAUDE_OPUS_|_QWEN_|_DOUBAO_|_BYO_API-2f9e44?style=for-the-badge" alt="Recommended model profiles">
@@ -73,11 +73,13 @@ Skill 会下载公开 Release 的插件包和校验文件，验证 SHA-256，只
 
 ## 运行完整 OpenGUI 技术栈
 
-如果要运行完整的 OpenGUI 后端和 Android 客户端，可以让 Claude Code 或 Codex 帮你完成启动。
+如果要运行完整的 OpenGUI 后端和 Android 客户端，可以让 Claude Code、Codex 或 OpenCode 帮你完成启动。
 
 ```text
 Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
 ```
+
+这段显式指定 Skill 路径的提示词同样适用于 OpenCode。当前仓库把 Skill 放在顶层 `skills/` 目录，因此 OpenCode 用户应像上面一样明确提供路径，而不是依赖自动发现。OpenCode 原生支持的 `.opencode/skills/` 和 `.agents/skills/` 目录可参考其 [Agent Skills 文档](https://opencode.ai/docs/skills/)。
 
 你需要准备：
 
@@ -129,8 +131,8 @@ OpenGUI 让 AI 操作真实的 Android 手机。
 
 - **操作主流 Android App**：让 AI 在真实手机上执行 X、Reddit、Hacker News、Telegram、微信、微博、小红书等移动任务。
 - **运行现成工作流**：仓库已经包含可直接启动的后端、Android 客户端、待命派发链路，以及部分预置任务能力。
-- **让 Claude 或 Codex 帮你跑起来**：把 [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) 交给模型，直接用自然语言描述目标，让它处理安装、构建、安装 APK 和本地排障。
-- **让 Codex 控制 Android App**：OpenGUI 启动后，把 [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) 交给 Codex 或 Claude Code，用本地 CLI 列设备、下发任务并查询 execution 状态。
+- **让 AI 编码 Agent 帮你跑起来**：把 [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) 交给 Claude Code、Codex 或 OpenCode，直接用自然语言描述目标，让它处理安装、构建、安装 APK 和本地排障。
+- **让 AI 编码 Agent 控制 Android App**：OpenGUI 启动后，把 [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md) 交给 Claude Code、Codex 或 OpenCode，用本地 CLI 列设备、下发任务并查询 execution 状态。
 - **把手机当成远程 worker 使用**：通过飞书、Telegram、Discord 或 REST API 下发任务，让设备保持待命，并从后端拿回结构化结果。
 - [加入 Discord 社区](https://discord.gg/pqHHw7XgJ3)
 
@@ -192,13 +194,13 @@ OpenGUI 采用的是一套分层清晰的移动 operator system。
 
 ## 怎么使用 OpenGUI
 
-### 1. 用 Claude 或 Codex 帮你跑起来
+### 1. 用 Claude Code、Codex 或 OpenCode 帮你跑起来
 
 优先从 [`skills/open-gui-bootstrap/SKILL.md`](./skills/open-gui-bootstrap/SKILL.md) 开始。
 
 推荐流程很简单：
 
-1. 把 skill 交给 Claude 或 Codex
+1. 把 Skill 交给 Claude Code、Codex 或 OpenCode
 2. 直接用自然语言描述目标
 3. 让模型处理后端 bootstrap、APK 构建、安装和本地排障
 
@@ -210,7 +212,7 @@ OpenGUI 采用的是一套分层清晰的移动 operator system。
 - 授予悬浮窗或电池权限
 - 提供 API Key 或机器人密钥
 
-后端和 Android client 跑起来后，可以继续使用 [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md)，让 Codex 或 Claude Code 通过本地 CLI 控制手机：
+后端和 Android client 跑起来后，可以继续使用 [`skills/open-gui-remote-control/SKILL.md`](./skills/open-gui-remote-control/SKILL.md)，让 Claude Code、Codex 或 OpenCode 通过本地 CLI 控制手机：
 
 ```bash
 cd server

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -2,7 +2,7 @@
 
 This repository already contains the runnable backend and Android client.
 
-## Option 1: Bootstrap with Claude or Codex
+## Option 1: Bootstrap with Claude Code, Codex, or OpenCode
 
 Start with the bootstrap skill:
 
@@ -13,6 +13,12 @@ Recommended prompt:
 ```text
 Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
 ```
+
+The same prompt works in OpenCode. Because this repository keeps the Skill in
+the top-level `skills/` directory, specify the path explicitly as shown above.
+OpenCode's automatic discovery instead searches locations such as
+`.opencode/skills/` and `.agents/skills/`; see its [Agent Skills documentation](https://opencode.ai/docs/skills/).
+No OpenCode-specific OpenGUI configuration is required.
 
 The skill should use the repository scripts directly:
 

--- a/skills/open-gui-bootstrap/SKILL.md
+++ b/skills/open-gui-bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-gui-bootstrap
-description: Launch and bootstrap OpenGUI from a plain-language user request. Use when Claude or Codex should install, configure, debug, and run the actual backend and Android client shipped in this repository while keeping manual setup to a minimum.
+description: Launch and bootstrap OpenGUI from a plain-language user request. Use when an AI coding agent such as Claude Code, Codex, or OpenCode should install, configure, debug, and run the backend and Android client shipped in this repository while keeping manual setup to a minimum.
 ---
 
 # OpenGUI Bootstrap
@@ -37,6 +37,7 @@ Typical trigger forms include:
 - "Install OpenGUI for me"
 - "Use Claude to start OpenGUI"
 - "Use Codex to get OpenGUI running"
+- "Use OpenCode to get OpenGUI running"
 - "Set up OpenGUI with my model APIs"
 - "Only tell me the phone-side steps"
 
@@ -45,16 +46,17 @@ Typical trigger forms include:
 - "Help me run OpenGUI on this machine."
 - "Use Claude Opus to bootstrap OpenGUI for me."
 - "Use Codex to get OpenGUI running and only tell me what I need to do on the phone."
+- "Use OpenCode to get OpenGUI running and only tell me what I need to do on the phone."
 - "Set up OpenGUI with Qwen 3.6 Plus for planning and Doubao Pro for VLM."
 - "Use my existing model APIs and get OpenGUI working."
 - "Help me bring up OpenGUI for a long mobile workflow."
 
 ## Core Rules
 
-- Treat Codex or Claude as the installer and operator.
+- Treat the current AI coding agent as the installer and operator.
 - Use the repository's actual scripts before inventing a custom flow.
 - Default to doing the work directly instead of explaining how to do it.
-- Do not ask the user to run terminal commands that Codex can run.
+- Do not ask the user to run terminal commands that the agent can run.
 - Ask the user only for physical actions, OS dialogs, secrets, or Android device interaction.
 - Before claiming setup is complete, verify each major step.
 - If the checkout is missing `server/` or `client/`, say so clearly and stop.

--- a/skills/open-gui-bootstrap/references/setup-flow.md
+++ b/skills/open-gui-bootstrap/references/setup-flow.md
@@ -4,7 +4,7 @@ Use this reference when executing the bootstrap workflow.
 
 ## Operating Principle
 
-Claude or Codex should behave like the installer and operator.
+The AI coding agent, including Claude Code, Codex, or OpenCode, should behave like the installer and operator.
 
 The user should only need to:
 

--- a/skills/open-gui-remote-control/SKILL.md
+++ b/skills/open-gui-remote-control/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: open-gui-remote-control
-description: Control an Android phone through OpenGUI from Codex or Claude Code. Use when an agent should list online devices, run a natural-language mobile task, check execution status, pause, resume, or cancel through the local OpenGUI backend and CLI.
+description: Control an Android phone through OpenGUI from an AI coding agent such as Claude Code, Codex, or OpenCode. Use when an agent should list online devices, run a natural-language mobile task, check execution status, pause, resume, or cancel through the local OpenGUI backend and CLI.
 ---
 
 # OpenGUI Remote Control
 
-Use this skill when Codex or Claude Code needs to operate an Android phone through OpenGUI.
+Use this skill when an AI coding agent such as Claude Code, Codex, or OpenCode needs to operate an Android phone through OpenGUI.
 
 The agent should not drive the phone with raw `adb shell input` commands. The supported path is:
 
 ```text
-Codex / Claude Code
+Claude Code / Codex / OpenCode
   -> server CLI or REST API
   -> OpenGUI backend task/execution services
   -> standby dispatch
@@ -24,6 +24,7 @@ Start this skill when the user asks for any of these:
 
 - "Use OpenGUI to control my phone"
 - "让 Codex 操控手机"
+- "Use OpenCode to control my phone through OpenGUI"
 - "Run this task on the Android device"
 - "Use the OpenGUI CLI"
 - "List OpenGUI devices"
@@ -36,7 +37,7 @@ If the user asks to install or bootstrap OpenGUI from scratch, use `open-gui-boo
 
 - First obtain or locate a runnable OpenGUI checkout. The CLI cannot work without the repository.
 - Use the repository CLI first: `cd server && pnpm opengui -- ...`.
-- Use `--json` whenever the result will be parsed by Codex or Claude Code.
+- Use `--json` whenever the result will be parsed by the coding agent.
 - Do not ask the user to run terminal commands that the agent can run.
 - Ask the user only for physical phone actions, Android permissions, or missing secrets.
 - Do not change Android socket event names or payloads.

--- a/skills/open-gui-remote-control/agents/openai.yaml
+++ b/skills/open-gui-remote-control/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "OpenGUI Remote Control"
-  short_description: "Control an Android phone through OpenGUI from Codex or Claude Code."
-  default_prompt: "Use this skill when Codex or Claude Code should operate an Android phone through OpenGUI. First locate or clone the runnable https://github.com/Core-Mate/open-gui checkout, then prefer the server CLI with --json, list online devices first, dispatch tasks through the backend remote-control route, poll execution status, and ask the user only for phone-side permissions or missing secrets."
+  short_description: "Control Android through OpenGUI from coding agents."
+  default_prompt: "Use $open-gui-remote-control to operate an Android phone through the local OpenGUI backend and CLI."


### PR DESCRIPTION
## What changed?

- documented OpenCode support in the English, Chinese, and Japanese READMEs
- added the explicit Skill path required by the current repository layout
- documented OpenCode's native Skill discovery directories
- updated the getting-started guide and both OpenGUI Skills to include OpenCode
- kept the bootstrap and remote-control guidance consistent across coding agents

## Why?

OpenGUI's Skills and repository scripts already work with OpenCode, but the public documentation only named Claude Code and Codex. Users also need to know that the current top-level `skills/` directory is not one of OpenCode's automatic discovery locations, so the Skill path should be provided explicitly.

## Testing

- `git diff --check`
- validated `open-gui-bootstrap` with the Skill validator
- validated `open-gui-remote-control` with the Skill validator
- verified the official OpenCode Agent Skills documentation link returns HTTP 200
- checked OpenCode guidance across all three README languages

## Device verification

Not applicable — documentation and Skill metadata only.

## Notes

Fixes #52
