### PR TITLE
docs: clarify that root access is not required

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -81,6 +81,8 @@ Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me f
 
 Skill のパスを明示したこのプロンプトは OpenCode でも使用できます。このリポジトリでは Skill をトップレベルの `skills/` に配置しているため、OpenCode では自動検出に頼らず、上記のようにパスを指定してください。OpenCode が標準で検出する `.opencode/skills/` と `.agents/skills/` については、[Agent Skills ドキュメント](https://opencode.ai/docs/skills/)を参照してください。
 
+root 権限やブートローダーのアンロックは不要です。OpenGUI は Android 標準の `AccessibilityService` API を使ってスクリーンショットを取得し、タップ、スワイプ、テキスト入力、戻る、ホームなどの操作を実行します。ADB はローカルでの APK のインストールと起動、および `adb reverse` によるポート転送の設定にのみ使用され、端末を root 化したりシステムを変更したりすることはありません。
+
 必要なもの:
 
 - Android 11（API 30）以降のスマートフォンまたはエミュレーター

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ This explicit prompt also works in OpenCode. The repository keeps the Skill in
 on automatic Skill discovery. See the [OpenCode Agent Skills documentation](https://opencode.ai/docs/skills/)
 for its native `.opencode/skills/` and `.agents/skills/` locations.
 
+Root access and an unlocked bootloader are not required. OpenGUI uses standard
+Android `AccessibilityService` APIs for screenshots and actions. ADB is used
+only to install and launch the APK and configure local port forwarding with
+`adb reverse`; it does not root the device or modify the Android system.
+
 You will need:
 
 - an Android 11 (API 30) or newer phone or emulator

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,6 +81,8 @@ Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me f
 
 这段显式指定 Skill 路径的提示词同样适用于 OpenCode。当前仓库把 Skill 放在顶层 `skills/` 目录，因此 OpenCode 用户应像上面一样明确提供路径，而不是依赖自动发现。OpenCode 原生支持的 `.opencode/skills/` 和 `.agents/skills/` 目录可参考其 [Agent Skills 文档](https://opencode.ai/docs/skills/)。
 
+无需 Root，也无需解锁 Bootloader。OpenGUI 使用 Android 标准的 `AccessibilityService` API 获取截图，并执行点击、滑动、输入、返回和主页等操作。ADB 仅用于在本地安装和启动 APK，以及通过 `adb reverse` 配置端口转发；它不会 Root 或修改设备系统。
+
 你需要准备：
 
 - 一台 Android 11（API 30）或更高版本的手机或模拟器

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -74,6 +74,12 @@ Useful endpoints after startup:
 
 ### 2. Connect a device and install the Android client
 
+Root access and an unlocked bootloader are not required. OpenGUI captures
+screenshots and performs gestures through Android's standard
+`AccessibilityService` APIs. ADB is used to install and launch the APK and to
+configure `adb reverse` for the local backend; it does not root or modify the
+Android system.
+
 The current Android client requires Android 11 (API 30) or newer. Android 9
 (API 28) and other older releases are not supported by the screenshot-based
 execution path. The client currently targets Android 15 (API 35).


### PR DESCRIPTION
## What changed?

- clarified in the English, Chinese, and Japanese READMEs that OpenGUI does not require root access or an unlocked bootloader
- documented that screenshots and actions use Android's standard `AccessibilityService` APIs
- explained that ADB is used for APK installation, launch, and local `adb reverse` port forwarding
- added the same clarification to the getting-started guide

## Why?

Users should be able to determine before installation that OpenGUI can run on a normal daily-use Android device without rooting it or unlocking the bootloader.

## Testing

- `git diff --check`
- checked the no-root wording across all three README languages
- verified the documentation against the current `GestureService`, accessibility service configuration, and `client/start.sh` flow

## Device verification

Not applicable — documentation only; no Android behavior changed.

## Notes

Fixes #47
