### PR TITLE
docs: localize setup guide and clarify adb reverse

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -12,7 +12,7 @@
   <img src="https://img.shields.io/badge/SYSTEM-MULTI_ROLE_OPERATOR-1f6feb?style=for-the-badge" alt="マルチロールオペレーターシステム">
   <img src="https://img.shields.io/badge/TASKS-UP_TO_12_HOURS-cf222e?style=for-the-badge" alt="最大12時間のタスク">
   <img src="https://img.shields.io/badge/MODELS-CLAUDE_OPUS_|_QWEN_|_DOUBAO_|_BYO_API-2f9e44?style=for-the-badge" alt="推奨モデルプロファイル">
-  <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="手動セットアップドキュメント"></a>
+  <a href="./docs/get-started.ja-JP.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="手動セットアップドキュメント"></a>
 </p>
 
 <p align="center">
@@ -120,7 +120,7 @@ pnpm opengui -- do "Observe the current Android screen and summarize what you se
 pnpm opengui -- cancel <executionId> --json
 ```
 
-手動セットアップガイド: [`docs/get-started.md`](./docs/get-started.md)
+手動セットアップガイド: [`docs/get-started.ja-JP.md`](./docs/get-started.ja-JP.md)
 
 ## 最近の更新
 
@@ -283,7 +283,7 @@ cd client
 
 参考ドキュメント:
 
-- [docs/get-started.md](./docs/get-started.md)
+- [docs/get-started.ja-JP.md](./docs/get-started.ja-JP.md)
 - [server/start.sh](./server/start.sh)
 - [client/start.sh](./client/start.sh)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
@@ -338,7 +338,7 @@ flowchart LR
 ## ドキュメント
 
 - [skills/open-gui-bootstrap/SKILL.md](./skills/open-gui-bootstrap/SKILL.md)
-- [docs/get-started.md](./docs/get-started.md)
+- [docs/get-started.ja-JP.md](./docs/get-started.ja-JP.md)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
 - [docs/DISCORD.ja-JP.md](./docs/DISCORD.ja-JP.md)
 - [client/README.md](./client/README.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,7 +12,7 @@
   <img src="https://img.shields.io/badge/SYSTEM-MULTI_ROLE_OPERATOR-1f6feb?style=for-the-badge" alt="Multi-role operator system">
   <img src="https://img.shields.io/badge/TASKS-UP_TO_12_HOURS-cf222e?style=for-the-badge" alt="Tasks up to 12 hours">
   <img src="https://img.shields.io/badge/MODELS-CLAUDE_OPUS_|_QWEN_|_DOUBAO_|_BYO_API-2f9e44?style=for-the-badge" alt="Recommended model profiles">
-  <a href="./docs/get-started.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="Manual setup docs"></a>
+  <a href="./docs/get-started.zh-CN.md"><img src="https://img.shields.io/badge/MANUAL_SETUP-DOCS-4b4b4b?style=for-the-badge" alt="手动安装文档"></a>
 </p>
 
 <p align="center">
@@ -120,7 +120,7 @@ pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，
 pnpm opengui -- cancel <executionId> --json
 ```
 
-手动安装指南：[`docs/get-started.md`](./docs/get-started.md)。
+手动安装指南：[`docs/get-started.zh-CN.md`](./docs/get-started.zh-CN.md)。
 
 ## 近期更新
 
@@ -284,7 +284,7 @@ cd client
 
 参考文档：
 
-- [docs/get-started.md](./docs/get-started.md)
+- [docs/get-started.zh-CN.md](./docs/get-started.zh-CN.md)
 - [server/start.sh](./server/start.sh)
 - [client/start.sh](./client/start.sh)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
@@ -338,7 +338,7 @@ flowchart LR
 ## 文档
 
 - [skills/open-gui-bootstrap/SKILL.md](./skills/open-gui-bootstrap/SKILL.md)
-- [docs/get-started.md](./docs/get-started.md)
+- [docs/get-started.zh-CN.md](./docs/get-started.zh-CN.md)
 - [server/apps/backend/README.md](./server/apps/backend/README.md)
 - [docs/DISCORD.zh-CN.md](./docs/DISCORD.zh-CN.md)
 - [client/README.md](./client/README.md)

--- a/docs/get-started.ja-JP.md
+++ b/docs/get-started.ja-JP.md
@@ -1,0 +1,117 @@
+<p align="center">
+  <strong>言語:</strong> <a href="./get-started.md">English</a> | <a href="./get-started.zh-CN.md">简体中文</a> | <a href="./get-started.ja-JP.md">日本語</a>
+</p>
+
+# OpenGUI スタートガイド
+
+このリポジトリには、実行可能なバックエンドと Android クライアントが含まれています。
+
+## 方法 1：Claude Code、Codex、または OpenCode でブートストラップする
+
+まず Bootstrap Skill を使用します。
+
+- [`skills/open-gui-bootstrap/SKILL.md`](../skills/open-gui-bootstrap/SKILL.md)
+
+推奨プロンプト：
+
+```text
+Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
+```
+
+同じプロンプトを OpenCode でも使用できます。このリポジトリでは Skill をトップレベルの `skills/` ディレクトリに配置しているため、上記のようにパスを明示してください。OpenCode の自動検出では `.opencode/skills/` や `.agents/skills/` などが検索されます。詳細は [Agent Skills ドキュメント](https://opencode.ai/docs/skills/)を参照してください。OpenGUI 固有の OpenCode 設定は必要ありません。
+
+Skill はリポジトリのスクリプトを直接使用します。
+
+- `server/start.sh`
+- `client/start.sh`
+
+## 方法 2：手動セットアップ
+
+### 1. バックエンドを起動する
+
+```bash
+cd server
+./start.sh
+```
+
+`server/start.sh` が行うこと：
+
+- Node.js 22+、pnpm、Docker を確認する
+- Docker で PostgreSQL と Redis を起動する
+- 初回実行時に `.env.example` から `server/apps/backend/.env` を作成する
+- 依存関係をインストールする
+- Prisma client を生成する
+- schema を反映し、バックエンドの初期データを投入する
+- ポート `7777` でバックエンドを起動する
+
+初回のデフォルト設定では、モデル API キーだけを追加します。
+
+- `VLM_API_KEY`
+
+現在のバックエンドでは、`VLM_*` 変数を graph agent 共通の OpenAI 互換モデル設定として使用します。これらは、プランニング、監督、要約、および executor のビジョン処理で使用されます。
+
+`VLM_BASE_URL` と `VLM_MODEL` には `.env.example` でデフォルト値が設定されています。別の OpenAI 互換プロバイダーまたはモデルを使用する場合にだけ変更してください。
+
+例：
+
+```env
+VLM_API_KEY=your_api_key
+VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+VLM_MODEL=qwen3.6-plus
+```
+
+`VLM_API_KEY` がなくてもバックエンドは起動できますが、graph がモデルを呼び出す段階で実際のタスク実行は失敗します。初回実行では LangSmith tracing と IM channel の認証情報は任意です。
+
+起動後に利用できるエンドポイント：
+
+- API：`http://localhost:7777/api`
+- ドキュメント：`http://localhost:7777/docs`
+
+### 2. 端末を接続して Android クライアントをインストールする
+
+root 権限やブートローダーのアンロックは不要です。OpenGUI は Android 標準の `AccessibilityService` API を使ってスクリーンショットを取得し、ジェスチャーを実行します。ADB は APK のインストールと起動、およびローカルバックエンド用の `adb reverse` の設定にだけ使用され、Android システムを root 化したり変更したりすることはありません。
+
+現在の Android クライアントには Android 11（API 30）以降が必要です。Android 9（API 28）など、それ以前のバージョンは現在のスクリーンショットベースの実行パスをサポートしていません。現在のクライアントは Android 15（API 35）をターゲットにしています。
+
+```bash
+cd client
+./start.sh
+```
+
+`client/start.sh` が行うこと：
+
+- `adb` と Java を確認する
+- 接続済みの Android 端末を確認する
+- `adb reverse tcp:7777 tcp:7777` を実行する
+- debug APK をビルドする
+- APK をインストールする
+- `com.coremate.opengui/.login.SplashActivity` を起動する
+
+`adb reverse` のマッピングは現在の ADB 端末接続に紐づいています。端末を切断して再接続した場合、端末を再起動した場合、または ADB サーバーを再起動した場合は、マッピングが失われることがあります。Android クライアントからローカルバックエンドへ接続できなくなった場合は、端末を再接続して次を実行してください。
+
+```bash
+adb reverse tcp:7777 tcp:7777
+```
+
+`client/start.sh` を再実行してもマッピングを再作成できます。
+
+### 3. 端末側の権限設定を完了する
+
+アプリを開き、次を有効にします。
+
+- USB デバッグの承認
+- ユーザー補助サービス
+- オーバーレイ権限
+- 必要に応じて OpenGUI をバッテリー最適化の対象外にする
+
+## 現在のソース公開ビルドの動作
+
+現在のソース公開ビルドでは、Android アプリは以前のログイン処理をスキップし、直接 `HomeActivity` を開きます。
+
+ローカル実行では、バックエンドの task controller もデフォルトで `userId = 1` を使用するため、初回セットアップは以前の OTP フローに依存しません。
+
+## 詳細情報
+
+- バックエンド：[`server/apps/backend/README.md`](../server/apps/backend/README.md)
+- Discord リモートコントロール：[`docs/DISCORD.ja-JP.md`](./DISCORD.ja-JP.md)
+- Android クライアント：[`client/README.md`](../client/README.md)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <strong>Language:</strong> <a href="./get-started.md">English</a> | <a href="./get-started.zh-CN.md">简体中文</a> | <a href="./get-started.ja-JP.md">日本語</a>
+</p>
+
 # OpenGUI Getting Started
 
 This repository already contains the runnable backend and Android client.
@@ -97,6 +101,17 @@ What `client/start.sh` does:
 - builds the debug APK
 - installs the APK
 - launches `com.coremate.opengui/.login.SplashActivity`
+
+The `adb reverse` mapping belongs to the current ADB device connection. It may
+be lost after the phone is disconnected and reconnected, the phone reboots, or
+the ADB server restarts. If the Android client can no longer reach the local
+backend, reconnect the device and run:
+
+```bash
+adb reverse tcp:7777 tcp:7777
+```
+
+Running `client/start.sh` again also recreates the mapping.
 
 ### 3. Complete phone-side permissions
 

--- a/docs/get-started.zh-CN.md
+++ b/docs/get-started.zh-CN.md
@@ -1,0 +1,117 @@
+<p align="center">
+  <strong>语言切换：</strong><a href="./get-started.md">English</a> | <a href="./get-started.zh-CN.md">简体中文</a> | <a href="./get-started.ja-JP.md">日本語</a>
+</p>
+
+# OpenGUI 快速入门
+
+本仓库已经包含可运行的后端和 Android 客户端。
+
+## 方式一：使用 Claude Code、Codex 或 OpenCode 启动
+
+首先使用 Bootstrap Skill：
+
+- [`skills/open-gui-bootstrap/SKILL.md`](../skills/open-gui-bootstrap/SKILL.md)
+
+推荐提示词：
+
+```text
+Read ./skills/open-gui-bootstrap/SKILL.md and help me run OpenGUI. Only ask me for phone-side actions.
+```
+
+同一段提示词也适用于 OpenCode。由于本仓库将 Skill 放在顶层 `skills/` 目录中，请像上面一样明确指定路径。OpenCode 的自动发现机制会查找 `.opencode/skills/`、`.agents/skills/` 等目录；详情请参阅其 [Agent Skills 文档](https://opencode.ai/docs/skills/)。OpenGUI 不需要额外的 OpenCode 专用配置。
+
+Skill 应直接使用仓库脚本：
+
+- `server/start.sh`
+- `client/start.sh`
+
+## 方式二：手动配置
+
+### 1. 启动后端
+
+```bash
+cd server
+./start.sh
+```
+
+`server/start.sh` 会执行以下操作：
+
+- 检查 Node.js 22+、pnpm 和 Docker
+- 在 Docker 中启动 PostgreSQL 和 Redis
+- 首次运行时，根据 `.env.example` 创建 `server/apps/backend/.env`
+- 安装依赖
+- 生成 Prisma client
+- 推送数据库 schema 并写入默认后端数据
+- 在 `7777` 端口启动后端
+
+首次使用默认配置时，只需添加模型 API Key：
+
+- `VLM_API_KEY`
+
+后端目前使用 `VLM_*` 变量作为 graph agent 共用的 OpenAI 兼容模型配置。规划、监督、总结和 executor 的视觉链路都会使用这些变量。
+
+`.env.example` 已为 `VLM_BASE_URL` 和 `VLM_MODEL` 提供默认值。只有在使用其他 OpenAI 兼容服务商或模型时才需要修改。
+
+示例：
+
+```env
+VLM_API_KEY=your_api_key
+VLM_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+VLM_MODEL=qwen3.6-plus
+```
+
+没有 `VLM_API_KEY` 时后端仍可启动，但 graph 需要调用模型时，真实任务将执行失败。首次运行不需要配置 LangSmith tracing 和 IM channel 凭据。
+
+启动后可使用以下地址：
+
+- API：`http://localhost:7777/api`
+- 文档：`http://localhost:7777/docs`
+
+### 2. 连接设备并安装 Android 客户端
+
+OpenGUI 不需要 Root，也不需要解锁 Bootloader。OpenGUI 通过 Android 标准的 `AccessibilityService` API 获取截图并执行手势。ADB 只用于安装和启动 APK，以及为本地后端配置 `adb reverse`；它不会 Root 或修改 Android 系统。
+
+当前 Android 客户端要求 Android 11（API 30）或更高版本。Android 9（API 28）及其他更早版本不支持当前基于截图的执行链路。客户端目前以 Android 15（API 35）为目标版本。
+
+```bash
+cd client
+./start.sh
+```
+
+`client/start.sh` 会执行以下操作：
+
+- 检查 `adb` 和 Java
+- 要求连接一台 Android 设备
+- 执行 `adb reverse tcp:7777 tcp:7777`
+- 构建 debug APK
+- 安装 APK
+- 启动 `com.coremate.opengui/.login.SplashActivity`
+
+`adb reverse` 映射属于当前 ADB 设备连接。手机断开后重新连接、手机重启或 ADB 服务重启后，该映射可能会丢失。如果 Android 客户端无法再次连接本地后端，请重新连接设备并执行：
+
+```bash
+adb reverse tcp:7777 tcp:7777
+```
+
+重新运行 `client/start.sh` 也会重新创建该映射。
+
+### 3. 完成手机端权限配置
+
+打开应用并启用：
+
+- USB 调试授权
+- 无障碍服务
+- 悬浮窗权限
+- 必要时允许 OpenGUI 忽略电池优化
+
+## 当前源码开放版本的行为
+
+当前源码开放版本的 Android 应用会跳过旧的登录流程，直接进入 `HomeActivity`。
+
+本地运行时，后端任务 controller 也默认使用 `userId = 1`，因此首次配置不再依赖旧的 OTP 流程。
+
+## 更多资料
+
+- 后端详情：[`server/apps/backend/README.md`](../server/apps/backend/README.md)
+- Discord 远程控制：[`docs/DISCORD.zh-CN.md`](./DISCORD.zh-CN.md)
+- Android 客户端详情：[`client/README.md`](../client/README.md)


### PR DESCRIPTION
## What changed?

- Added complete Simplified Chinese and Japanese versions of the manual setup guide.
- Added language navigation to all three setup guides.
- Updated the Chinese and Japanese READMEs so every manual-setup link opens the matching localized guide.
- Clarified that `adb reverse` may need to be reapplied after a USB reconnect, phone reboot, or ADB server restart.

## Why?

The reverse-port mapping belongs to the current ADB device connection. Users could reconnect a phone and find that the Android client no longer reaches the local backend without knowing that the mapping must be recreated.

Closes #39.

## Testing

- Verified that all relative documentation links resolve.
- Confirmed that the three guides have matching sections, lists, commands, and configuration blocks.
- Checked that each README links only to its matching guide language.
- Confirmed that `client/start.sh` runs `adb reverse tcp:7777 tcp:7777`.
- Ran `git diff --check`.

## Device verification

Not applicable — documentation-only change.

## Notes

No runtime code or device behavior was changed.
