### PR TITLE
chore(release): prepare dsh-coremate-mobile v0.1.7

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -41,7 +41,7 @@ OpenGUI は実際の Android アプリ UI を読み取り、次のステップ�
 macOSでは、固定バージョンのインストーラーSkillをCodexに実行させる方法が最短です。Node.js 22.19以降または24以降が必要で、互換性のあるDSHバージョンは自動的にインストールされます。次の内容を1つのプロンプトとして送信します：
 
 ```text
-Install and run the OpenGUI installer Skill from https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.5/deepseek-harness-plugin/skills/opengui-coremate-install for my DSH web profile. Only ask me for phone-side authorization and model credentials.
+Install and run the OpenGUI installer Skill from https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.7/deepseek-harness-plugin/skills/opengui-coremate-install for my DSH web profile. Proceed autonomously, and only pause when I need to authorize or select a phone, add or select a DSH workspace, or provide fallback visual-model credentials.
 ```
 
 Skillは公開ReleaseのパッケージとチェックサムをダウンロードしてSHA-256を検証し、OpenGUIプラグインだけをインストールします。必要な場合はDSHを起動して開き、既存のプラグインと設定は保持します。DSHがすでに起動していた場合は、一度再起動するとプラグインが読み込まれます。LinuxまたはWindowsでは、[手動パッケージガイド](./deepseek-harness-plugin/README.md#1-download-the-release-package)を使用してください。
@@ -52,7 +52,7 @@ Skillは公開Releaseのパッケージとチェックサムをダウンロー�
 @OpenGUI Open Settings and report the Android version
 ```
 
-このプラグインは、OpenGUIバックエンド一式を必要とせず、DSHにスマートフォンとブラウザの操作機能を追加します。[ユースケース](./deepseek-harness-plugin/docs/use-cases.md)を確認するか、[v0.1.5リリースパッケージ](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.5)をダウンロードできます。
+このプラグインは、OpenGUIバックエンド一式を必要とせず、DSHにスマートフォンとブラウザの操作機能を追加します。[ユースケース](./deepseek-harness-plugin/docs/use-cases.md)を確認するか、[v0.1.7リリースパッケージ](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7)をダウンロードできます。
 
 主なユースケース：
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ OpenGUI reads a real Android app UI, plans the next step, takes mobile actions, 
 The shortest path on macOS is to let Codex run the pinned installer Skill. It requires Node.js 22.19+ or 24+ and installs the compatible DSH version automatically. Paste this as one prompt:
 
 ```text
-Install and run the OpenGUI installer Skill from https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.5/deepseek-harness-plugin/skills/opengui-coremate-install for my DSH web profile. Only ask me for phone-side authorization and model credentials.
+Install and run the OpenGUI installer Skill from https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.7/deepseek-harness-plugin/skills/opengui-coremate-install for my DSH web profile. Proceed autonomously, and only pause when I need to authorize or select a phone, add or select a DSH workspace, or provide fallback visual-model credentials.
 ```
 
 The Skill downloads the public release package and checksum, verifies SHA-256, installs only the OpenGUI plugin, starts DSH when needed, and opens DSH. It preserves unrelated DSH plugins and settings. If DSH was already running, restart it once to load the plugin. For Linux or Windows, use the [manual package guide](./deepseek-harness-plugin/README.md#1-download-the-release-package).
@@ -53,7 +53,7 @@ After installation, add or select a DSH workspace, connect and select an authori
 @OpenGUI Open Settings and report the Android version
 ```
 
-The plugin adds phone and browser operation to DSH without requiring the full OpenGUI backend stack. See more [use cases](./deepseek-harness-plugin/docs/use-cases.md) or download the [v0.1.5 release package](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.5).
+The plugin adds phone and browser operation to DSH without requiring the full OpenGUI backend stack. See more [use cases](./deepseek-harness-plugin/docs/use-cases.md) or download the [v0.1.7 release package](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7).
 
 Good fits include:
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@ OpenGUI 会读取真实 Android App 界面，规划下一步操作，执行移�
 macOS 上最短的路径，是让 Codex 运行固定版本的安装 Skill。环境需要 Node.js 22.19+ 或 24+，兼容的 DSH 版本会自动安装。把下面整段作为一条消息发给 Codex：
 
 ```text
-请安装并运行这个 OpenGUI 安装 Skill：https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.5/deepseek-harness-plugin/skills/opengui-coremate-install，把插件安装到我的 DSH web profile。只在需要手机端授权或模型凭据时询问我。
+请安装并运行这个 OpenGUI 安装 Skill：https://github.com/Core-Mate/OpenGUI/tree/dsh-coremate-mobile-v0.1.7/deepseek-harness-plugin/skills/opengui-coremate-install，把插件安装到我的 DSH web profile。请自主完成安装，仅在需要我授权或选择手机、添加或选择 DSH workspace，或者提供备用视觉模型凭据时暂停并询问我。
 ```
 
 Skill 会下载公开 Release 的插件包和校验文件，验证 SHA-256，只安装 OpenGUI 插件，在需要时启动并打开 DSH，同时保留其他 DSH 插件和设置。如果 DSH 原本正在运行，重启一次即可加载插件。Linux 或 Windows 用户可按[手动安装说明](./deepseek-harness-plugin/README.zh.md#1-下载发布包)操作。
@@ -52,7 +52,7 @@ Skill 会下载公开 Release 的插件包和校验文件，验证 SHA-256，只
 @OpenGUI 打开设置并报告 Android 版本
 ```
 
-插件可以直接为 DSH 增加手机与浏览器操作能力，不需要部署完整的 OpenGUI 后端。你还可以查看更多[使用场景](./deepseek-harness-plugin/docs/use-cases.zh.md)，或下载 [v0.1.5 安装包](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.5)。
+插件可以直接为 DSH 增加手机与浏览器操作能力，不需要部署完整的 OpenGUI 后端。你还可以查看更多[使用场景](./deepseek-harness-plugin/docs/use-cases.zh.md)，或下载 [v0.1.7 安装包](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7)。
 
 适合的使用场景包括：
 

--- a/deepseek-harness-plugin/.codex-plugin/plugin.json
+++ b/deepseek-harness-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opengui",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Control one to four local Android phones through bounded screenshots and allowlisted actions from Codex or DeepSeek Harness.",
   "author": {
     "name": "Core Mate",

--- a/deepseek-harness-plugin/README.md
+++ b/deepseek-harness-plugin/README.md
@@ -50,16 +50,16 @@ The examples use the `web` profile and the default `$DSH_HOME=~/.dsh`. Substitut
 
 ### macOS: install with the Codex Skill
 
-Ask Codex to install the repository skill from [`deepseek-harness-plugin/skills/opengui-coremate-install`](./skills/opengui-coremate-install), then invoke `$opengui-coremate-install`. The Skill downloads and verifies the pinned `v0.1.6` package from the public OpenGUI Release, preserves the rest of the `web` profile, and installs a per-user LaunchAgent so DSH returns after a crash or login. GitHub login is not required.
+Ask Codex to install the repository skill from [`deepseek-harness-plugin/skills/opengui-coremate-install`](./skills/opengui-coremate-install), then invoke `$opengui-coremate-install`. The Skill downloads and verifies the pinned `v0.1.7` package from the public OpenGUI Release, preserves the rest of the `web` profile, and installs a per-user LaunchAgent so DSH returns after a crash or login. GitHub login is not required.
 
 If port 3080 belongs to an OpenGUI-managed DSH, the installer safely reloads that LaunchAgent. It never terminates an unowned DSH process; in that case the new LaunchAgent takes over after the next login. The manual package flow below remains available on every supported host.
 
 ### 1. Download the release package
 
-Download these files from the [public OpenGUI Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.6):
+Download these files from the [public OpenGUI Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7):
 
-- `dsh-coremate-mobile-0.1.6.tgz`
-- `dsh-coremate-mobile-0.1.6.tgz.sha256`
+- `dsh-coremate-mobile-0.1.7.tgz`
+- `dsh-coremate-mobile-0.1.7.tgz.sha256`
 
 Do not extract the `.tgz`, and do not use GitHub's automatically generated source archives.
 
@@ -67,18 +67,18 @@ From the directory containing both files, verify the package:
 
 ```sh
 # Linux
-sha256sum -c dsh-coremate-mobile-0.1.6.tgz.sha256
+sha256sum -c dsh-coremate-mobile-0.1.7.tgz.sha256
 
 # macOS
-shasum -a 256 -c dsh-coremate-mobile-0.1.6.tgz.sha256
+shasum -a 256 -c dsh-coremate-mobile-0.1.7.tgz.sha256
 ```
 
-On Windows PowerShell, run `Get-FileHash .\dsh-coremate-mobile-0.1.6.tgz -Algorithm SHA256` and `Get-Content .\dsh-coremate-mobile-0.1.6.tgz.sha256`, then confirm that the displayed hashes match.
+On Windows PowerShell, run `Get-FileHash .\dsh-coremate-mobile-0.1.7.tgz -Algorithm SHA256` and `Get-Content .\dsh-coremate-mobile-0.1.7.tgz.sha256`, then confirm that the displayed hashes match.
 
 ### 2. Install into a Harness profile
 
 ```sh
-dsh plugin --profile web add /absolute/path/dsh-coremate-mobile-0.1.6.tgz
+dsh plugin --profile web add /absolute/path/dsh-coremate-mobile-0.1.7.tgz
 ```
 
 If you run the official CLI through `npx`, replace `dsh` in the commands with:
@@ -259,7 +259,7 @@ This is an advanced option: a profile patch replaces the target row's entire `co
 Production installations should use the prebuilt release package above. For development, clone the public OpenGUI release tag and install the plugin directory:
 
 ```sh
-git clone --branch dsh-coremate-mobile-v0.1.6 --depth 1 https://github.com/Core-Mate/OpenGUI.git
+git clone --branch dsh-coremate-mobile-v0.1.7 --depth 1 https://github.com/Core-Mate/OpenGUI.git
 cd OpenGUI/deepseek-harness-plugin
 dsh plugin --profile web add "$(pwd)"
 ```

--- a/deepseek-harness-plugin/README.zh.md
+++ b/deepseek-harness-plugin/README.zh.md
@@ -52,16 +52,16 @@ codex plugin add opengui@opengui-local
 
 ### macOS：通过 Codex Skill 安装
 
-让 Codex 从仓库的 [`deepseek-harness-plugin/skills/opengui-coremate-install`](./skills/opengui-coremate-install) 安装 Skill，然后调用 `$opengui-coremate-install`。Skill 会从 OpenGUI 的公开 Release 下载并校验固定的 `v0.1.6` 安装包，保留 `web` profile 中的其他配置，并安装用户级 LaunchAgent，让 DSH 在异常退出或重新登录后自动恢复；不要求登录 GitHub。
+让 Codex 从仓库的 [`deepseek-harness-plugin/skills/opengui-coremate-install`](./skills/opengui-coremate-install) 安装 Skill，然后调用 `$opengui-coremate-install`。Skill 会从 OpenGUI 的公开 Release 下载并校验固定的 `v0.1.7` 安装包，保留 `web` profile 中的其他配置，并安装用户级 LaunchAgent，让 DSH 在异常退出或重新登录后自动恢复；不要求登录 GitHub。
 
 如果 3080 端口属于 OpenGUI 管理的 DSH，安装器会安全更新并重启对应 LaunchAgent；如果属于其他 DSH 进程，安装器绝不会强制终止它，新 LaunchAgent 会在下次登录后接管。下面的手动安装方式仍适用于所有受支持的系统。
 
 ### 1. 下载发布包
 
-从 [OpenGUI 公开 Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.6) 下载：
+从 [OpenGUI 公开 Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7) 下载：
 
-- `dsh-coremate-mobile-0.1.6.tgz`
-- `dsh-coremate-mobile-0.1.6.tgz.sha256`
+- `dsh-coremate-mobile-0.1.7.tgz`
+- `dsh-coremate-mobile-0.1.7.tgz.sha256`
 
 不要解压 `.tgz`，也不要下载 GitHub 自动生成的 Source code 压缩包。
 
@@ -69,18 +69,18 @@ codex plugin add opengui@opengui-local
 
 ```sh
 # Linux
-sha256sum -c dsh-coremate-mobile-0.1.6.tgz.sha256
+sha256sum -c dsh-coremate-mobile-0.1.7.tgz.sha256
 
 # macOS
-shasum -a 256 -c dsh-coremate-mobile-0.1.6.tgz.sha256
+shasum -a 256 -c dsh-coremate-mobile-0.1.7.tgz.sha256
 ```
 
-Windows PowerShell 可分别执行 `Get-FileHash .\dsh-coremate-mobile-0.1.6.tgz -Algorithm SHA256` 和 `Get-Content .\dsh-coremate-mobile-0.1.6.tgz.sha256`，确认两者显示的哈希一致。
+Windows PowerShell 可分别执行 `Get-FileHash .\dsh-coremate-mobile-0.1.7.tgz -Algorithm SHA256` 和 `Get-Content .\dsh-coremate-mobile-0.1.7.tgz.sha256`，确认两者显示的哈希一致。
 
 ### 2. 安装到 Harness profile
 
 ```sh
-dsh plugin --profile web add /绝对路径/dsh-coremate-mobile-0.1.6.tgz
+dsh plugin --profile web add /绝对路径/dsh-coremate-mobile-0.1.7.tgz
 ```
 
 如果使用 `npx` 启动官方 CLI，可将命令中的 `dsh` 替换为：
@@ -261,7 +261,7 @@ OpenGUI 任务运行时，输入框右侧会出现方形“停止 OpenGUI 操作
 生产环境应使用上面的预构建 Release 包。开发时可以 checkout OpenGUI 的公开 Release tag，再安装插件目录：
 
 ```sh
-git clone --branch dsh-coremate-mobile-v0.1.6 --depth 1 https://github.com/Core-Mate/OpenGUI.git
+git clone --branch dsh-coremate-mobile-v0.1.7 --depth 1 https://github.com/Core-Mate/OpenGUI.git
 cd OpenGUI/deepseek-harness-plugin
 dsh plugin --profile web add "$(pwd)"
 ```

--- a/deepseek-harness-plugin/codex-public/.codex-plugin/plugin.json
+++ b/deepseek-harness-plugin/codex-public/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opengui",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Guide Codex through safe local Android control with OpenGUI's packaged CLI and bounded observation workflow.",
   "author": {
     "name": "Core Mate",

--- a/deepseek-harness-plugin/docs/install-for-beginners.zh.md
+++ b/deepseek-harness-plugin/docs/install-for-beginners.zh.md
@@ -4,7 +4,7 @@
 
 ## 目前能不能直接安装？
 
-可以。从 [OpenGUI 的公开 Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.6) 打开插件版本，在 Assets 中下载 `dsh-coremate-mobile-0.1.6.tgz`。
+可以。从 [OpenGUI 的公开 Release](https://github.com/Core-Mate/OpenGUI/releases/tag/dsh-coremate-mobile-v0.1.7) 打开插件版本，在 Assets 中下载 `dsh-coremate-mobile-0.1.7.tgz`。
 
 下载后不要解压。不要下载 “Source code (zip)” 或 “Source code (tar.gz)”；它们是 GitHub 自动生成的源码压缩包，不是普通用户安装包。
 
@@ -13,7 +13,7 @@
 开始前确认以下事项：
 
 1. 电脑已经能启动官方 DeepSeek Harness；当前已验证版本为 `0.1.0-rc.7`。
-2. 已下载 `dsh-coremate-mobile-0.1.6.tgz`，并且没有解压。
+2. 已下载 `dsh-coremate-mobile-0.1.7.tgz`，并且没有解压。
 3. 电脑能访问公开的 GitHub Releases；不需要登录 GitHub。
 4. Node.js 版本为 `22.19.x`，或 `24` 及以上。如果 `node --version` 不在这个范围，请先切换到受支持版本。
 5. Harness 当前对话里已选择一个模型。该模型最好支持图片输入和工具调用；如果不兼容，OpenGUI 会在第一次真实任务时引导配置专用视觉模型。
@@ -42,9 +42,9 @@ npx @deepseek-ai/dsh@0.1.0-rc.7 --help
 npx @deepseek-ai/dsh@0.1.0-rc.7 plugin --profile web add 
 ```
 
-找到下载好的 `dsh-coremate-mobile-0.1.6.tgz`，用鼠标把它拖进终端窗口，终端会自动填入文件路径，然后按回车。
+找到下载好的 `dsh-coremate-mobile-0.1.7.tgz`，用鼠标把它拖进终端窗口，终端会自动填入文件路径，然后按回车。
 
-看到 `dsh-coremate-mobile 0.1.6` 和安装完成信息，表示插件文件已经加入 Harness。此时还没有证明插件能够启动；第五步会进行实际装载验证。
+看到 `dsh-coremate-mobile 0.1.7` 和安装完成信息，表示插件文件已经加入 Harness。此时还没有证明插件能够启动；第五步会进行实际装载验证。
 
 ### 如果出现 `ERR_PNPM_IGNORED_BUILDS`
 

--- a/deepseek-harness-plugin/docs/public-submission/release-notes.md
+++ b/deepseek-harness-plugin/docs/public-submission/release-notes.md
@@ -1,4 +1,4 @@
-# OpenGUI 0.1.6 Plugin Release Notes
+# OpenGUI 0.1.7 Plugin Release Notes
 
 - Adds a Codex plugin manifest, repo marketplace entry, and `opengui:control` Skill beside the existing DeepSeek Harness plugin.
 - Adds seven local stdio MCP interfaces and the equivalent persistent local CLI transport.

--- a/deepseek-harness-plugin/docs/research/deepseek-harness-plugin-integration.md
+++ b/deepseek-harness-plugin/docs/research/deepseek-harness-plugin-integration.md
@@ -112,7 +112,7 @@ pnpm dsh plugin --profile web add ../Deepseek-ai
 插件迁入 OpenGUI monorepo 后，不应把仓库根目录当作插件包直接交给 DSH。开发验证应固定插件 release tag，checkout 后安装其中的 `deepseek-harness-plugin` 目录：
 
 ```sh
-git clone --branch dsh-coremate-mobile-v0.1.6 --depth 1 \
+git clone --branch dsh-coremate-mobile-v0.1.7 --depth 1 \
   https://github.com/Core-Mate/OpenGUI.git
 cd OpenGUI/deepseek-harness-plugin
 pnpm build

--- a/deepseek-harness-plugin/package.json
+++ b/deepseek-harness-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-coremate-mobile",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Dual-host OpenGUI plugin for DeepSeek Harness and Codex Android control",
   "repository": {
     "type": "git",

--- a/deepseek-harness-plugin/scripts/validate-codex-plugin.mjs
+++ b/deepseek-harness-plugin/scripts/validate-codex-plugin.mjs
@@ -13,8 +13,8 @@ const publicPlugin = await json('codex-public/.codex-plugin/plugin.json')
 const mcp = await json('.mcp.json')
 const marketplace = await json('../.agents/plugins/marketplace.json')
 
-if (pkg.version !== '0.1.6' || plugin.version !== pkg.version || publicPlugin.version !== pkg.version) {
-  throw new Error('package, Codex, and public Skills-only versions must all be 0.1.6')
+if (pkg.version !== '0.1.7' || plugin.version !== pkg.version || publicPlugin.version !== pkg.version) {
+  throw new Error('package, Codex, and public Skills-only versions must all be 0.1.7')
 }
 if (pkg.name !== 'dsh-coremate-mobile' || plugin.name !== 'opengui' || publicPlugin.name !== 'opengui') {
   throw new Error('internal package identity or public OpenGUI identity changed unexpectedly')

--- a/deepseek-harness-plugin/skills/opengui-coremate-install/SKILL.md
+++ b/deepseek-harness-plugin/skills/opengui-coremate-install/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: opengui-coremate-install
-description: Install the pinned OpenGUI v0.1.6 release into a DeepSeek Harness web profile on macOS. Use when the user asks to download, install, update, open, or verify OpenGUI for DSH.
+description: Install the pinned OpenGUI v0.1.7 release into a DeepSeek Harness web profile on macOS. Use when the user asks to download, install, update, open, or verify OpenGUI for DSH.
 ---
 
 # Install OpenGUI
 
-Install and verify the signed-off `v0.1.6` release without replacing unrelated DSH plugins or settings.
+Install and verify the signed-off `v0.1.7` release without replacing unrelated DSH plugins or settings.
 
 ## Run the installer
 

--- a/deepseek-harness-plugin/skills/opengui-coremate-install/agents/openai.yaml
+++ b/deepseek-harness-plugin/skills/opengui-coremate-install/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "OpenGUI Installer"
-  short_description: "Install verified OpenGUI v0.1.6 into DSH on macOS"
+  short_description: "Install verified OpenGUI v0.1.7 into DSH on macOS"
   icon_small: "./assets/opengui-mark.svg"
   icon_large: "./assets/opengui-wordmark.svg"
   brand_color: "#F1BF1F"
-  default_prompt: "Use $opengui-coremate-install to download, verify, install, and open OpenGUI v0.1.6 for my DSH web profile."
+  default_prompt: "Use $opengui-coremate-install to download, verify, install, and open OpenGUI v0.1.7 for my DSH web profile."

--- a/deepseek-harness-plugin/skills/opengui-coremate-install/scripts/install-macos.sh
+++ b/deepseek-harness-plugin/skills/opengui-coremate-install/scripts/install-macos.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-release_version="0.1.6"
+release_version="0.1.7"
 dsh_version="0.1.0-rc.7"
 profile="web"
 port="${COREMATE_INSTALL_PORT_OVERRIDE:-3080}"

--- a/deepseek-harness-plugin/tests/codex-plugin.spec.ts
+++ b/deepseek-harness-plugin/tests/codex-plugin.spec.ts
@@ -21,7 +21,7 @@ describe('Codex plugin package', () => {
     const [pkg, plugin, publicPlugin] = await Promise.all([
       json('package.json'), json('.codex-plugin/plugin.json'), json('codex-public/.codex-plugin/plugin.json'),
     ])
-    expect([pkg.version, plugin.version, publicPlugin.version]).toEqual(['0.1.6', '0.1.6', '0.1.6'])
+    expect([pkg.version, plugin.version, publicPlugin.version]).toEqual(['0.1.7', '0.1.7', '0.1.7'])
     expect(pkg.name).toBe('dsh-coremate-mobile')
     expect(plugin).toMatchObject({ name: 'opengui', skills: './skills/', mcpServers: './.mcp.json' })
     expect(publicPlugin).toMatchObject({ name: 'opengui', skills: './skills/' })

--- a/deepseek-harness-plugin/tests/install-skill.spec.ts
+++ b/deepseek-harness-plugin/tests/install-skill.spec.ts
@@ -21,13 +21,13 @@ async function fixture() {
   const root = await mkdtemp(join(tmpdir(), 'coremate-install-skill-'))
   roots.push(root)
   const bin = join(root, 'bin')
-  const release = join(root, 'release', 'dsh-coremate-mobile-v0.1.6')
+  const release = join(root, 'release', 'dsh-coremate-mobile-v0.1.7')
   const home = join(root, 'dsh-home')
   await Promise.all([mkdir(bin, { recursive: true }), mkdir(release, { recursive: true })])
-  const archive = join(release, 'dsh-coremate-mobile-0.1.6.tgz')
+  const archive = join(release, 'dsh-coremate-mobile-0.1.7.tgz')
   await writeFile(archive, 'verified release fixture')
   const { stdout: checksum } = await exec('shasum', ['-a', '256', archive])
-  await writeFile(`${archive}.sha256`, `${checksum.trim().split(/\s+/u)[0]}  dsh-coremate-mobile-0.1.6.tgz\n`)
+  await writeFile(`${archive}.sha256`, `${checksum.trim().split(/\s+/u)[0]}  dsh-coremate-mobile-0.1.7.tgz\n`)
   await writeFile(join(bin, 'lsof'), `#!/usr/bin/env bash
 if [[ "\${FAKE_DSH_RUNNING:-0}" == "1" ]]; then
   [[ " $* " == *" -t "* ]] && printf '%s\\n' 4242
@@ -48,7 +48,7 @@ if [[ "\${1:-}" == "plugin" && "\${4:-}" == "remove" ]]; then rm -rf "\${DSH_HOM
 profile_dir="\${DSH_HOME}/profiles/web"
 mkdir -p "\${profile_dir}/node_modules/dsh-coremate-mobile/lib/types/client"
 printf '%s\\n' '{"dependencies":{"dsh-coremate-mobile":"file:fixture"},"dsh":{"profile":{"bundles":["dsh-coremate-mobile"]}}}' > "\${profile_dir}/package.json"
-printf '%s\\n' '{"name":"dsh-coremate-mobile","version":"0.1.6"}' > "\${profile_dir}/node_modules/dsh-coremate-mobile/package.json"
+printf '%s\\n' '{"name":"dsh-coremate-mobile","version":"0.1.7"}' > "\${profile_dir}/node_modules/dsh-coremate-mobile/package.json"
 printf '%s\\n' 'opengui command host with legacy coremate alias' > "\${profile_dir}/node_modules/dsh-coremate-mobile/lib/index.js"
 printf '%s\\n' 'client bundle' > "\${profile_dir}/node_modules/dsh-coremate-mobile/lib/client.js"
 printf '%s\\n' 'export {}' > "\${profile_dir}/node_modules/dsh-coremate-mobile/lib/types/client/index.d.ts"
@@ -88,7 +88,7 @@ describe('macOS installation Skill', () => {
   it('installs and verifies a first release, then repeats without replacing profile files', async () => {
     const value = await fixture()
     const first = await run(value)
-    expect(first.stdout).toContain('Installed and verified dsh-coremate-mobile v0.1.6')
+    expect(first.stdout).toContain('Installed and verified dsh-coremate-mobile v0.1.7')
     const marker = join(value.home, 'profiles', 'web', 'user-setting.txt')
     await writeFile(marker, 'keep me')
     const repeated = await run(value)


### PR DESCRIPTION
## Summary

- bump the DeepSeek Harness and Codex plugin package to 0.1.7
- pin the macOS installer Skill and release documentation to 0.1.7
- update installer, plugin-manifest, and release validation tests
- replace stale 0.1.5/0.1.6 installation links in the public READMEs
- clarify that model credentials are only needed for the fallback visual model

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run check`
- 39 test files passed
- 212 tests passed, 1 skipped
- TypeScript and bundled builds passed
- Codex plugin structure validation passed

## Release handoff

After merging, `HarveySang` must create and push the tag `dsh-coremate-mobile-v0.1.7`. The release workflow intentionally runs only when that account pushes the tag.