### PR TITLE
docs: clarify execution status workflow

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -114,7 +114,13 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 ```
 
-タスクのレスポンスには `executionId` が含まれます。実行中のタスクを停止できるように、この値を控えておいてください：
+`do` は execution を非同期で開始し、execution の作成後に戻ります。進捗をストリーミングしたり、完了まで待機したりはしません。レスポンスに含まれる `executionId` を使って現在の状態を確認します。
+
+```bash
+pnpm opengui -- status <executionId> --json
+```
+
+`status` は実行時点のスナップショットを 1 回返します。更新を確認するには、もう一度実行してください。`executionStatus` と、レスポンスに含まれる場合は `statusMessage`、`currentStep`、`executionResult`、`errorMessage` を確認します。`PENDING` は端末側での開始待ち、`RUNNING` は実行中、`FINISHED` は終了済みを意味します。詳細なフィールドは常に含まれるとは限らないため、`RUNNING` だけではモデル待ちか端末待ちかを区別できない場合があります。`do` 自体が `executionId` を返さない場合は、通常の非同期実行ではなく、リクエストまたは起動の問題として確認してください。実行中のタスクを停止する場合も、同じ `executionId` を使用します。
 
 ```bash
 pnpm opengui -- cancel <executionId> --json

--- a/README.md
+++ b/README.md
@@ -122,7 +122,23 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen and summarize what you see" --json
 ```
 
-The task response includes an `executionId`. Keep it so you can stop the active task:
+`do` starts the execution asynchronously and returns after the execution is
+created; it does not stream progress or wait for completion. The response
+includes an `executionId`. Use it to check the current status:
+
+```bash
+pnpm opengui -- status <executionId> --json
+```
+
+`status` returns one snapshot, so run it again whenever you want an update.
+Check `executionStatus` and, when present, `statusMessage`, `currentStep`,
+`executionResult`, or `errorMessage`. `PENDING` means the execution is waiting
+to start on the phone, `RUNNING` means it is active, and `FINISHED` means it has
+completed. Fine-grained fields are not always present, so a `RUNNING` snapshot
+may not distinguish a model wait from a phone wait. If `do` itself does not
+return an `executionId`, treat that as a request or startup problem rather than
+normal asynchronous execution. Keep the same `executionId` if you need to stop
+the active task:
 
 ```bash
 pnpm opengui -- cancel <executionId> --json

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,7 +114,13 @@ pnpm opengui -- devices --json
 pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，然后结束" --json
 ```
 
-任务响应中会返回 `executionId`。请保留它，以便停止正在执行的任务：
+`do` 会异步启动 execution，并在创建完成后返回；它不会持续输出进度，也不会等待任务结束。响应中会包含 `executionId`，使用它查询当前状态：
+
+```bash
+pnpm opengui -- status <executionId> --json
+```
+
+`status` 每次返回一个状态快照，需要更新时可以再次执行。请查看 `executionStatus`，以及返回结果中存在的 `statusMessage`、`currentStep`、`executionResult` 或 `errorMessage`。`PENDING` 表示 execution 正在等待手机端启动，`RUNNING` 表示正在执行，`FINISHED` 表示已经结束。细粒度字段不一定始终存在，因此 `RUNNING` 状态不一定能区分当前是在等待模型还是等待手机。如果 `do` 本身没有返回 `executionId`，应将其视为请求或启动异常，而不是正常的异步执行。需要停止正在执行的任务时，继续使用同一个 `executionId`：
 
 ```bash
 pnpm opengui -- cancel <executionId> --json

--- a/docs/codex-remote-control.ja-JP.md
+++ b/docs/codex-remote-control.ja-JP.md
@@ -89,10 +89,15 @@ Skill はリポジトリ内の CLI を優先して使用します。対応する
 cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "現在の Android 画面を確認し、表示内容を簡潔に説明してから終了してください" --json
+```
+
+`do` は execution を非同期で開始し、execution の作成後に戻ります。進捗をストリーミングしたり、完了まで待機したりはしません。レスポンスに含まれる `executionId` を使って現在の状態を確認します。
+
+```bash
 pnpm opengui -- status <executionId> --json
 ```
 
-`do` のレスポンスには `executionId` が含まれます。実行中のタスクを停止できるように、この値を控えておいてください：
+`status` は実行時点のスナップショットを 1 回返します。更新を確認するには、もう一度実行してください。`executionStatus` と、レスポンスに含まれる場合は `statusMessage`、`currentStep`、`executionResult`、`errorMessage` を確認します。`PENDING` は端末側での開始待ち、`RUNNING` は実行中、`FINISHED` は終了済みを意味します。詳細なフィールドは常に含まれるとは限らないため、`RUNNING` だけではモデル待ちか端末待ちかを区別できない場合があります。`do` 自体が `executionId` を返さない場合は、通常の非同期実行ではなく、リクエストまたは起動の問題として確認してください。実行中のタスクを停止する場合も、同じ `executionId` を使用します。
 
 ```bash
 pnpm opengui -- cancel <executionId> --json

--- a/docs/codex-remote-control.md
+++ b/docs/codex-remote-control.md
@@ -89,10 +89,25 @@ The Skill uses the repository CLI first. The equivalent local commands are:
 cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "Observe the current Android screen, briefly describe what you see, and then finish" --json
+```
+
+`do` starts the execution asynchronously and returns after the execution is
+created; it does not stream progress or wait for completion. The response
+includes an `executionId`. Use it to check the current status:
+
+```bash
 pnpm opengui -- status <executionId> --json
 ```
 
-The `do` response includes an `executionId`. Keep it so you can stop the active task:
+`status` returns one snapshot, so run it again whenever you want an update.
+Check `executionStatus` and, when present, `statusMessage`, `currentStep`,
+`executionResult`, or `errorMessage`. `PENDING` means the execution is waiting
+to start on the phone, `RUNNING` means it is active, and `FINISHED` means it has
+completed. Fine-grained fields are not always present, so a `RUNNING` snapshot
+may not distinguish a model wait from a phone wait. If `do` itself does not
+return an `executionId`, treat that as a request or startup problem rather than
+normal asynchronous execution. Keep the same `executionId` if you need to stop
+the active task:
 
 ```bash
 pnpm opengui -- cancel <executionId> --json

--- a/docs/codex-remote-control.zh-CN.md
+++ b/docs/codex-remote-control.zh-CN.md
@@ -89,10 +89,15 @@ Skill 会优先使用仓库里的 CLI。对应的本地命令是：
 cd server
 pnpm opengui -- devices --json
 pnpm opengui -- do "观察当前手机屏幕，简要描述你看到了什么，然后结束" --json
+```
+
+`do` 会异步启动 execution，并在创建完成后返回；它不会持续输出进度，也不会等待任务结束。响应中会包含 `executionId`，使用它查询当前状态：
+
+```bash
 pnpm opengui -- status <executionId> --json
 ```
 
-`do` 的响应中会返回 `executionId`。请保留它，以便停止正在执行的任务：
+`status` 每次返回一个状态快照，需要更新时可以再次执行。请查看 `executionStatus`，以及返回结果中存在的 `statusMessage`、`currentStep`、`executionResult` 或 `errorMessage`。`PENDING` 表示 execution 正在等待手机端启动，`RUNNING` 表示正在执行，`FINISHED` 表示已经结束。细粒度字段不一定始终存在，因此 `RUNNING` 状态不一定能区分当前是在等待模型还是等待手机。如果 `do` 本身没有返回 `executionId`，应将其视为请求或启动异常，而不是正常的异步执行。需要停止正在执行的任务时，继续使用同一个 `executionId`：
 
 ```bash
 pnpm opengui -- cancel <executionId> --json


### PR DESCRIPTION
## What changed?

- Clarified that `do` starts an execution asynchronously and does not stream progress or wait for completion.
- Added the `status <executionId>` command directly after the first observe-task example.
- Documented the status snapshot fields and the meanings of `PENDING`, `RUNNING`, and `FINISHED`.
- Clarified that fine-grained fields may not always distinguish a model wait from a phone wait.
- Documented that `do` returning no `executionId` is a request or startup problem, not normal asynchronous behavior.
- Synchronized the guidance across the English, Simplified Chinese, and Japanese READMEs and remote-control guides.

## Why?

The first task example showed how to start and cancel an execution, but did not clearly explain how to check progress or that `status` returns a one-time snapshot. This made a normally running first task look stuck.

Closes #82.

## Testing

- Ran `node --test server/scripts/opengui-control.test.mjs` (6/6 tests passed).
- Verified the exact `do`, `status`, and `cancel` request methods and paths through the CLI request builder.
- Confirmed the documented response fields against the backend DTO.
- Verified the six documents for matching command order, localized concepts, balanced code fences, valid local links, and final newlines.
- Ran `git diff --check`.

## Device verification

Not applicable — documentation-only change.

## Notes

No runtime code or execution behavior was changed.
