### PR TITLE
fix(plugin): repair packaged ADB permissions and public updates

### DIFF
--- a/.github/workflows/deepseek-harness-plugin-release.yml
+++ b/.github/workflows/deepseek-harness-plugin-release.yml
@@ -156,6 +156,10 @@ jobs:
 
           Connected phones now show a screenshot immediately while OpenGUI prepares the live view in the background. Stream, decoder, and status failures keep the screenshot available with a retry action.
 
+          Bundled ADB now repairs missing execute bits on macOS and Linux before discovery, while custom ADB paths remain untouched. Device-detection failures surface their actionable diagnostic in the OpenGUI workbench and retry automatically.
+
+          The OpenGUI tab checks this public repository for newer stable \`dsh-coremate-mobile-v*\` releases, ignores unrelated Android APK releases, verifies the matching package checksum, and offers a user-approved update action when Harness is idle.
+
           The macOS installer now runs DSH through a per-user LaunchAgent and includes a matching uninstall script. Verified phone-view caches are shared across DSH profiles, including existing \`~/.dsh\` caches.
 
           Download both the \`.tgz\` package and its \`.sha256\` file. The recommended macOS path is the stable [Codex installer Skill](https://github.com/Core-Mate/OpenGUI/tree/main/deepseek-harness-plugin/skills/opengui-coremate-install), which resolves the latest stable plugin release each time it runs.

--- a/deepseek-harness-plugin/README.md
+++ b/deepseek-harness-plugin/README.md
@@ -208,6 +208,8 @@ The native **OpenGUI** tab owns phone selection and status. One authorized phone
 
 The native **OpenGUI** tab is a full-width device wall. It renders every visible phone in Host order and appends one connection guide, without reserving empty slots. A connected phone shows an uncropped JPEG preview immediately while OpenGUI prepares its low-latency H.264 view in the background, then switches automatically. Unsupported browsers and stream failures keep the screenshot preview available with a retry action. Each phone can also be opened in an optional independent mirror window.
 
+After startup, the plugin checks the public `Core-Mate/OpenGUI` GitHub Releases list in the background, at most once every six hours. It ignores Android APK, draft, and prerelease entries and considers only stable `dsh-coremate-mobile-v*` releases with a version-matched `.tgz` and `.sha256`. The OpenGUI tab offers **Update** only for a newer verified package. Installation is blocked while an OpenGUI task is active, keeps the current version intact on failure, and takes effect after Harness restarts.
+
 Selecting `@OpenGUI` opens the native input menu with free-form, QA, operations, and game-assistant choices. A scene only fills the composer and never submits automatically. A non-empty OpenGUI submission releases the composer immediately while the task continues in its owner session. Starting another DSH session opens a genuinely blank conversation; the original task keeps running there, with a compact link back from the new session.
 
 `/opengui` starts a restricted routing child that can call only `phone_agent`, `browser_agent`, or both sequentially when the task truly spans both targets. Phone work still creates one fixed-device child per selected phone. Only one OpenGUI task runs at a time, including tasks started through the legacy `/coremate` alias.
@@ -339,6 +341,6 @@ pnpm run check
 npm pack
 ```
 
-The [GitHub Release workflow](.github/workflows/release.yml) performs publishing. A tag must be `v` followed by the exact `package.json` version; never reuse an existing version tag. Compatibility is defined by `peerDependencies` in `package.json`.
+The repository-level [GitHub Release workflow](../.github/workflows/deepseek-harness-plugin-release.yml) performs publishing. A tag must be `dsh-coremate-mobile-v` followed by the exact `package.json` version; never reuse an existing version tag. Compatibility is defined by `peerDependencies` in `package.json`.
 
 See the [developer integration and verification record](docs/research/deepseek-harness-plugin-integration.md) for official Harness source setup, isolated-profile installation, configuration precedence, runtime verification, and removal evidence.

--- a/deepseek-harness-plugin/README.zh.md
+++ b/deepseek-harness-plugin/README.zh.md
@@ -210,6 +210,8 @@ Usage: /opengui <task>
 
 原生 **OpenGUI** Tab 是全宽设备照片墙。界面按 Host 顺序展示全部可见手机，并在末尾追加唯一的连接说明卡，不会为凑列数预留空卡。新检测到的手机先立即展示完整截图，后台自动准备低延迟实时画面，完成后无缝切换；普通用户不需要理解或批准底层组件。浏览器不支持或视频流失败时会继续显示截图，并提供重试。每台手机还可按需打开独立投屏窗口。
 
+插件启动后会在后台检查公开的 `Core-Mate/OpenGUI` GitHub Releases 列表，并将频率限制为每 6 小时最多一次。它会忽略 Android APK、草稿和预发布条目，只识别带版本匹配 `.tgz` 与 `.sha256` 的稳定 `dsh-coremate-mobile-v*` Release。只有发现更高版本时，OpenGUI Tab 才显示**更新**按钮；OpenGUI 任务运行期间禁止安装，失败时保留当前版本，成功后重启 Harness 生效。
+
 选中 `@OpenGUI` 后，原生输入菜单会显示自由描述、QA、运营和手游四个选项；场景只填入草稿，不会自动发送。提交非空 OpenGUI 任务后，输入框会立即恢复，任务继续写入所属会话。此时新建 DSH 会话会进入真正的空白对话，原任务仍在原会话运行，新会话中会提供紧凑的返回入口。
 
 `/opengui` 会启动一个受限的任务路由子任务，只能选择 `phone_agent`、`browser_agent`，或在确有必要时顺序调用两者。手机任务仍为每台已选手机创建一个绑定固定设备的子任务；普通对话也可以直接使用两个委派工具。同一时间只允许一个 OpenGUI 任务，包括通过旧 `/coremate` 别名启动的任务。
@@ -339,6 +341,6 @@ pnpm run check
 npm pack
 ```
 
-发布由 [GitHub Release workflow](.github/workflows/release.yml) 完成：tag 必须是 `v` 加 `package.json` 中的准确版本。不要重复使用已经存在的版本 tag。兼容范围以 `package.json` 的 `peerDependencies` 为准。
+发布由仓库级 [GitHub Release workflow](../.github/workflows/deepseek-harness-plugin-release.yml) 完成：tag 必须是 `dsh-coremate-mobile-v` 加 `package.json` 中的准确版本。不要重复使用已经存在的版本 tag。兼容范围以 `package.json` 的 `peerDependencies` 为准。
 
 完整的官方 Harness 源码准备、隔离 profile 安装、配置优先级、运行时验证和移除记录见[开发者接入与实测记录](docs/research/deepseek-harness-plugin-integration.md)。

--- a/deepseek-harness-plugin/src/adb.ts
+++ b/deepseek-harness-plugin/src/adb.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { access, stat } from 'node:fs/promises'
+import { access, chmod, stat } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
@@ -317,10 +317,27 @@ export function managedAdbPath(override?: string): string {
  * Fail before device discovery if the packaged runtime is missing or unusable.
  * @param path Absolute ADB executable path.
  */
-export async function assertAdbReady(path: string): Promise<void> {
+export async function assertAdbReady(path: string, options: { readonly repairPermissions?: boolean } = {}): Promise<void> {
   const info = await stat(path).catch(() => undefined)
   if (info?.isFile() !== true) throw new Error(`coremate-mobile: bundled ADB runtime is missing at ${path}; reinstall the plugin`)
-  await access(path, process.platform === 'win32' ? constants.F_OK : constants.X_OK)
+  if (process.platform === 'win32') {
+    await access(path, constants.F_OK)
+    return
+  }
+  try {
+    await access(path, constants.X_OK)
+  } catch (error) {
+    if (options.repairPermissions === true) {
+      try {
+        await chmod(path, info.mode | 0o111)
+        await access(path, constants.X_OK)
+        return
+      } catch (repairError) {
+        throw new Error('opengui: bundled ADB is not executable and automatic permission repair failed; reinstall the plugin', { cause: repairError })
+      }
+    }
+    throw new Error('opengui: configured ADB executable is not executable; check adbPath or OPENGUI_ADB_PATH and its file permissions', { cause: error })
+  }
 }
 
 /** Process limits applied to every ADB invocation. */

--- a/deepseek-harness-plugin/src/client/CoremateView.tsx
+++ b/deepseek-harness-plugin/src/client/CoremateView.tsx
@@ -13,6 +13,7 @@ import { OpenGuiMark } from './OpenGuiMark.tsx'
 import { mirrorBusy, mirrorLabel, mirrorProgress, postMirrorStatus, readMirrorStatus } from './MirrorButton.tsx'
 import { TaskStopButton } from './TaskStopButton.tsx'
 import { PhoneStream } from './PhoneStream.tsx'
+import { PluginUpdatePrompt } from './PluginUpdatePrompt.tsx'
 import { WECHAT_GROUP_QR_DATA_URL } from './wechat-group-qr.ts'
 
 const DISCORD_URL = 'https://discord.gg/pqHHw7XgJ3'
@@ -117,6 +118,22 @@ const connectStyle: CSSProperties = {
   background: 'color-mix(in srgb, var(--dsw-alias-bg-layer-1, #fff) 72%, transparent)',
   textAlign: 'center',
   boxSizing: 'border-box',
+}
+
+const detectionErrorStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'auto minmax(0, 1fr) auto',
+  alignItems: 'center',
+  gap: '6px 10px',
+  marginBottom: 16,
+  padding: '10px 12px',
+  border: '1px solid color-mix(in srgb, #dc2626 28%, transparent)',
+  borderRadius: 8,
+  color: '#991b1b',
+  background: 'color-mix(in srgb, #fee2e2 55%, var(--dsw-alias-bg-layer-1, #fff))',
+  fontSize: 12,
+  lineHeight: 1.5,
+  overflowWrap: 'anywhere',
 }
 
 export type DeviceWallItem =
@@ -252,14 +269,25 @@ export function CoremateView({ coremateSessionId }: { readonly coremateSessionId
           <a data-coremate-header-link href={OPENGUI_GITHUB_URL} target="_blank" rel="noreferrer" style={headerLinkStyle}>GitHub ↗</a>
           <a data-coremate-header-link href={OPENGUI_WEBSITE_URL} target="_blank" rel="noreferrer" style={headerLinkStyle}>官方网站 ↗</a>
           <span role="status" style={{ display: 'inline-flex', alignItems: 'center', gap: 7, minHeight: 40, padding: '0 6px', color: 'var(--dsw-alias-label-secondary, #52525b)', fontSize: 12, fontVariantNumeric: 'tabular-nums' }}>
-            <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: 999, background: status?.devices.some(device => device.connected) === true ? '#16a34a' : '#a1a1aa' }} />
-            {status === undefined ? '正在检测设备' : phaseLabel(status)}
+            <span aria-hidden="true" style={{ width: 6, height: 6, borderRadius: 999, background: error !== undefined ? '#dc2626' : status?.devices.some(device => device.connected) === true ? '#16a34a' : '#a1a1aa' }} />
+            {error !== undefined ? '设备检测异常' : status === undefined ? '正在检测设备' : phaseLabel(status)}
           </span>
           <TaskStopButton {...(coremateSessionId === undefined ? {} : { coremateSessionId })} />
         </div>
       </header>
 
-      <div style={{ position: 'sticky', top: 0, zIndex: 10 }}><BrowserInstallPrompt /></div>
+      <div style={{ position: 'sticky', top: 0, zIndex: 10 }}>
+        <PluginUpdatePrompt />
+        <BrowserInstallPrompt />
+      </div>
+
+      {error === undefined ? null : (
+        <div role="alert" style={detectionErrorStyle} data-coremate-detection-error>
+          <strong>设备检测异常</strong>
+          <span>{error}</span>
+          <span style={{ color: 'var(--dsw-alias-label-secondary, #52525b)', whiteSpace: 'nowrap' }}>正在自动重试…</span>
+        </div>
+      )}
 
       <section aria-label="设备照片墙" style={gridStyle} data-coremate-device-wall>
         {wallItems.map(item => {
@@ -330,7 +358,6 @@ export function CoremateView({ coremateSessionId }: { readonly coremateSessionId
         })}
       </section>
 
-      {error === undefined ? null : <p role="status" style={{ ...bodyStyle, color: '#b91c1c' }}>{error}</p>}
     </main>
   )
 }

--- a/deepseek-harness-plugin/src/client/MirrorButton.tsx
+++ b/deepseek-harness-plugin/src/client/MirrorButton.tsx
@@ -128,8 +128,14 @@ export function mirrorBusy(device: MirrorDeviceStatus): boolean {
 
 export async function readMirrorStatus(signal?: AbortSignal): Promise<MirrorStatus> {
   const response = await fetch(MIRROR_STATUS_PATH, { cache: 'no-store', ...(signal === undefined ? {} : { signal }) })
-  if (!response.ok) throw new Error(`手机状态请求失败 (${response.status})`)
-  return await response.json() as MirrorStatus
+  const value: unknown = await response.json().catch(() => undefined)
+  if (!response.ok) {
+    const message = typeof value === 'object' && value !== null && 'error' in value && typeof value.error === 'string'
+      ? value.error
+      : `手机状态请求失败 (${response.status})`
+    throw new Error(message)
+  }
+  return value as MirrorStatus
 }
 
 export async function postMirrorStatus(path: string, deviceIds: readonly string[]): Promise<MirrorStatus> {

--- a/deepseek-harness-plugin/src/client/PluginUpdatePrompt.tsx
+++ b/deepseek-harness-plugin/src/client/PluginUpdatePrompt.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from 'react'
+import type { CSSProperties } from 'react'
+import {
+  PLUGIN_UPDATE_CHECK_PATH,
+  PLUGIN_UPDATE_INSTALL_PATH,
+  PLUGIN_UPDATE_STATUS_PATH,
+} from '../mirror-contract.ts'
+import type { PluginUpdateStatus } from '../mirror-contract.ts'
+
+const ACTIVE_PHASES = new Set<PluginUpdateStatus['phase']>(['checking', 'downloading', 'verifying', 'installing'])
+
+const panelStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  flexWrap: 'wrap',
+  gap: 14,
+  marginBottom: 16,
+  padding: '14px 16px',
+  border: '1px solid color-mix(in srgb, #d9a900 48%, transparent)',
+  borderRadius: 10,
+  color: 'var(--dsw-alias-label-primary, #27272a)',
+  background: 'color-mix(in srgb, #f1bf1f 9%, var(--dsw-alias-bg-layer-1, #fff))',
+  boxSizing: 'border-box',
+}
+
+const buttonStyle: CSSProperties = {
+  minHeight: 40,
+  padding: '0 16px',
+  border: 0,
+  borderRadius: 7,
+  color: '#171717',
+  background: '#f1bf1f',
+  font: 'inherit',
+  fontSize: 13,
+  fontWeight: 750,
+  cursor: 'pointer',
+}
+
+export type PluginUpdatePresentation =
+  | { readonly kind: 'hidden' }
+  | { readonly kind: 'available', readonly title: string }
+  | { readonly kind: 'progress', readonly title: string, readonly percent?: number }
+  | { readonly kind: 'restart', readonly title: string }
+  | { readonly kind: 'error', readonly title: string }
+
+export function pluginUpdatePresentation(status?: PluginUpdateStatus, showTransient = false): PluginUpdatePresentation {
+  if (status === undefined) return { kind: 'hidden' }
+  switch (status.phase) {
+    case 'idle':
+    case 'up-to-date': return { kind: 'hidden' }
+    case 'checking': return showTransient ? { kind: 'progress', title: '正在检查 OpenGUI 更新…' } : { kind: 'hidden' }
+    case 'available': return { kind: 'available', title: `OpenGUI v${status.latestVersion ?? ''} 可用` }
+    case 'downloading': {
+      const percent = status.downloadedBytes !== undefined && status.totalBytes !== undefined && status.totalBytes > 0
+        ? Math.min(100, Math.max(0, Math.floor(status.downloadedBytes / status.totalBytes * 100)))
+        : undefined
+      return {
+        kind: 'progress',
+        title: percent === undefined ? '正在下载 OpenGUI 更新…' : `正在下载 OpenGUI 更新：${percent}%`,
+        ...(percent === undefined ? {} : { percent }),
+      }
+    }
+    case 'verifying': return { kind: 'progress', title: '正在校验 OpenGUI 更新…' }
+    case 'installing': return { kind: 'progress', title: '正在安装 OpenGUI 更新…' }
+    case 'restart-required': return { kind: 'restart', title: `OpenGUI v${status.latestVersion ?? ''} 已安装` }
+    case 'error': return showTransient ? { kind: 'error', title: status.message ?? 'OpenGUI 更新失败' } : { kind: 'hidden' }
+  }
+}
+
+async function readStatus(signal?: AbortSignal): Promise<PluginUpdateStatus> {
+  const response = await fetch(PLUGIN_UPDATE_STATUS_PATH, {
+    headers: { Accept: 'application/json' },
+    ...(signal === undefined ? {} : { signal }),
+  })
+  if (!response.ok) throw new Error(`读取更新状态失败（HTTP ${response.status}）`)
+  return response.json() as Promise<PluginUpdateStatus>
+}
+
+async function mutate(path: string): Promise<PluginUpdateStatus> {
+  const response = await fetch(path, { method: 'POST', headers: { Accept: 'application/json' } })
+  const body = await response.json().catch(() => ({})) as { error?: unknown } & Partial<PluginUpdateStatus>
+  if (!response.ok) {
+    const message = body.error === 'stop_the_active_opengui_task_before_updating'
+      ? '请先停止正在执行的 OpenGUI 任务，再进行更新。'
+      : body.error === 'no_plugin_update_available'
+        ? '当前没有可安装的 OpenGUI 更新，请重新检查。'
+        : typeof body.error === 'string' ? body.error : `更新请求失败（HTTP ${response.status}）`
+    throw new Error(message)
+  }
+  return body as PluginUpdateStatus
+}
+
+export function PluginUpdatePrompt(): JSX.Element | null {
+  const [status, setStatus] = useState<PluginUpdateStatus>()
+  const [actionStarted, setActionStarted] = useState(false)
+  const [requestError, setRequestError] = useState<string>()
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const poll = async (): Promise<void> => {
+      try {
+        const next = await readStatus(controller.signal)
+        setStatus(next)
+        if (!controller.signal.aborted) timer = setTimeout(poll, ACTIVE_PHASES.has(next.phase) ? 1_000 : 30_000)
+      } catch {
+        if (!controller.signal.aborted) timer = setTimeout(poll, 30_000)
+      }
+    }
+    void poll()
+    return () => {
+      controller.abort()
+      if (timer !== undefined) clearTimeout(timer)
+    }
+  }, [refreshKey])
+
+  const request = useCallback(async (path: string): Promise<void> => {
+    setActionStarted(true)
+    setRequestError(undefined)
+    try {
+      setStatus(await mutate(path))
+      setRefreshKey(value => value + 1)
+    } catch (error) {
+      setRequestError(error instanceof Error ? error.message : String(error))
+    }
+  }, [])
+
+  const presentation = requestError === undefined
+    ? pluginUpdatePresentation(status, actionStarted)
+    : { kind: 'error' as const, title: requestError }
+  if (presentation.kind === 'hidden') return null
+
+  const progress = presentation.kind === 'progress' ? presentation.percent : undefined
+  return (
+    <section style={panelStyle} role={presentation.kind === 'error' ? 'alert' : 'status'} data-coremate-plugin-update={presentation.kind}>
+      <div style={{ flex: '1 1 320px', minWidth: 0 }}>
+        <div style={{ fontSize: 14, fontWeight: 760 }}>{presentation.title}</div>
+        <p style={{ margin: '5px 0 0', color: 'var(--dsw-alias-label-secondary, #52525b)', fontSize: 12, lineHeight: 1.55 }}>
+          {presentation.kind === 'available'
+            ? `当前版本 v${status?.currentVersion}。更新包会从公开的 OpenGUI GitHub Release 下载并校验 SHA-256。`
+            : presentation.kind === 'restart'
+              ? (status?.message ?? '重启 Harness 后载入新版本。')
+              : presentation.kind === 'error'
+                ? '当前运行中的版本未改变，可以重试或稍后再更新。'
+                : '请保持 Harness 运行，完成后会提示重启。'}
+        </p>
+        {progress === undefined ? null : (
+          <div aria-label={`更新进度 ${progress}%`} style={{ width: 'min(360px, 100%)', height: 4, marginTop: 10, overflow: 'hidden', borderRadius: 999, background: 'rgba(128,128,128,.2)' }}>
+            <div style={{ width: `${progress}%`, height: '100%', background: '#d9a900', transition: 'width 160ms ease-out' }} />
+          </div>
+        )}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        {presentation.kind === 'available' && status?.releaseUrl !== undefined
+          ? <a href={status.releaseUrl} target="_blank" rel="noreferrer" style={{ color: 'inherit', fontSize: 12 }}>版本说明 ↗</a>
+          : null}
+        {presentation.kind === 'available'
+          ? <button data-coremate-press type="button" style={buttonStyle} onClick={() => { void request(PLUGIN_UPDATE_INSTALL_PATH) }}>更新</button>
+          : presentation.kind === 'error'
+            ? <button data-coremate-press type="button" style={{ ...buttonStyle, background: 'var(--dsw-alias-bg-layer-2, #f4f4f5)' }} onClick={() => { void request(PLUGIN_UPDATE_CHECK_PATH) }}>重新检查</button>
+            : null}
+      </div>
+    </section>
+  )
+}

--- a/deepseek-harness-plugin/src/codex/service.ts
+++ b/deepseek-harness-plugin/src/codex/service.ts
@@ -62,6 +62,7 @@ function codexStateDir(override?: string): string {
 /** Local USB/ADB Host adapter shared by the Codex MCP and CLI transports. */
 export class LocalAdbPhoneHost implements CodexPhoneHost {
   private readonly path: string
+  private readonly repairAdbPermissions: boolean
   private readonly timeoutMs: number
   private readonly fleet: DeviceFleet
   private readonly controller: PhoneController
@@ -71,7 +72,9 @@ export class LocalAdbPhoneHost implements CodexPhoneHost {
   private readonly previewPermits = new AsyncSemaphore(2)
 
   constructor(options: LocalAdbPhoneHostOptions = {}) {
-    this.path = managedAdbPath(options.adbPath ?? process.env.OPENGUI_ADB_PATH)
+    const configuredAdbPath = (options.adbPath ?? process.env.OPENGUI_ADB_PATH)?.trim()
+    this.path = managedAdbPath(configuredAdbPath)
+    this.repairAdbPermissions = !configuredAdbPath
     this.timeoutMs = options.commandTimeoutMs ?? COMMAND_TIMEOUT_MS
     const run = (args: readonly string[], signal: AbortSignal, buffer = false): Promise<string | Buffer> => this.run(args, signal, buffer)
     this.fleet = new DeviceFleet(async (signal) => parseDevices(String(await run(['devices', '-l'], signal))))
@@ -184,7 +187,7 @@ export class LocalAdbPhoneHost implements CodexPhoneHost {
   }
 
   private async run(args: readonly string[], signal: AbortSignal, buffer = false): Promise<string | Buffer> {
-    await assertAdbReady(this.path)
+    await assertAdbReady(this.path, { repairPermissions: this.repairAdbPermissions })
     return runAdb(this.path, args, {
       signal,
       timeoutMs: this.timeoutMs,

--- a/deepseek-harness-plugin/src/index.ts
+++ b/deepseek-harness-plugin/src/index.ts
@@ -69,6 +69,7 @@ import {
 } from './model-capability.ts'
 import { cleanCoremateSuggestionBlocks, COREMATE_SUGGESTION_INSTRUCTION } from './suggestions.ts'
 import { AsyncSemaphore } from './concurrency.ts'
+import { PluginUpdateManager } from './plugin-update.ts'
 
 export { actionCommand, canUseAdbInputText, managedAdbPath, normalizePhoneAction, ObservationId, parseDevices, parseScreenSize, selectAuthorizedSerial, textInputCommands } from './adb.ts'
 export type { AdbDevice, PhoneAction, PhoneCoordinateSpace, ScreenSize, TargetBoundingBox } from './adb.ts'
@@ -418,8 +419,9 @@ export function apply(ctx: Context, baseConfig: Config): void {
   })
   const adbPath = (): string => managedAdbPath(resolvedConfig(current()).adbPath)
   const run = async (args: readonly string[], signal: AbortSignal, buffer = false): Promise<string | Buffer> => {
+    const configuredAdbPath = resolvedConfig(current()).adbPath?.trim()
     const path = adbPath()
-    await assertAdbReady(path)
+    await assertAdbReady(path, { repairPermissions: !configuredAdbPath })
     return runAdb(path, args, {
       signal,
       timeoutMs: resolvedConfig(current()).commandTimeoutMs,
@@ -743,8 +745,8 @@ export function apply(ctx: Context, baseConfig: Config): void {
         questions: [{
           id: 'deviceConnection',
           header: '连接 Android 手机',
-          question: 'OpenGUI 需要先检测到一台已授权并选中的手机。',
-          detail: `${failure.message}\n\n请连接 USB，开启 USB 调试并在手机上允许这台电脑。连接多台手机时，请前往 OpenGUI Tab 选择至少一台。`,
+          question: 'OpenGUI 尚未检测到可用手机。',
+          detail: `${failure.message}\n\n请确认 USB 调试已授权；连接完成后点击“重新检测”。连接多台手机时，请先在 OpenGUI Tab 至少选择一台。`,
           options: [
             { label: '重新检测', description: '保持任务暂停，重新检查手机连接与选择。' },
             { label: '取消任务', description: '结束本次 OpenGUI 任务，不调用模型。' },
@@ -1019,9 +1021,11 @@ export function apply(ctx: Context, baseConfig: Config): void {
     state: () => tasks.state(),
     cancel: (): boolean => tasks.cancel(),
   }
-  installMirrorHttp(ctx, mirror, fleet, taskControl, managedBrowser, preview, streams)
+  const updater = new PluginUpdateManager()
+  installMirrorHttp(ctx, mirror, fleet, taskControl, managedBrowser, updater, preview, streams)
   ctx.effect(function* () {
     yield async () => {
+      updater.dispose()
       process.off('SIGTERM', cleanupForTermination)
       await forwardRecovery
       await Promise.all([mirror.dispose(), textInput.dispose(), streams.dispose()])

--- a/deepseek-harness-plugin/src/mirror-contract.ts
+++ b/deepseek-harness-plugin/src/mirror-contract.ts
@@ -43,6 +43,18 @@ export interface BrowserInstallStatus {
   message?: string
 }
 
+/** Release discovery and user-approved plugin update state exposed to the local client. */
+export interface PluginUpdateStatus {
+  phase: 'idle' | 'checking' | 'up-to-date' | 'available' | 'downloading' | 'verifying' | 'installing' | 'restart-required' | 'error'
+  currentVersion: string
+  latestVersion?: string
+  releaseUrl?: string
+  totalBytes?: number
+  downloadedBytes?: number
+  checkedAt?: string
+  message?: string
+}
+
 export const MIRROR_STATUS_PATH = '/coremate-mobile/mirror/status'
 export const DEVICE_SELECTION_PATH = '/coremate-mobile/devices/selection'
 export const DEVICE_PREVIEW_PATH = '/coremate-mobile/devices/preview'
@@ -56,3 +68,6 @@ export const PHONE_TASK_STOP_PATH = '/coremate-mobile/task/stop'
 export const BROWSER_INSTALL_STATUS_PATH = '/coremate-mobile/browser/install/status'
 export const BROWSER_INSTALL_APPROVE_PATH = '/coremate-mobile/browser/install/approve'
 export const BROWSER_INSTALL_DECLINE_PATH = '/coremate-mobile/browser/install/decline'
+export const PLUGIN_UPDATE_STATUS_PATH = '/coremate-mobile/plugin/update/status'
+export const PLUGIN_UPDATE_CHECK_PATH = '/coremate-mobile/plugin/update/check'
+export const PLUGIN_UPDATE_INSTALL_PATH = '/coremate-mobile/plugin/update/install'

--- a/deepseek-harness-plugin/src/mirror-http.ts
+++ b/deepseek-harness-plugin/src/mirror-http.ts
@@ -7,6 +7,7 @@ import {
   DEVICE_PREVIEW_PATH, DEVICE_SELECTION_PATH, DEVICE_STREAM_ENABLE_PATH, DEVICE_STREAM_PATH, DEVICE_STREAM_STATUS_PATH,
   MIRROR_START_PATH, MIRROR_STATUS_PATH, MIRROR_STOP_PATH,
   PHONE_TASK_STATUS_PATH, PHONE_TASK_STOP_PATH,
+  PLUGIN_UPDATE_CHECK_PATH, PLUGIN_UPDATE_INSTALL_PATH, PLUGIN_UPDATE_STATUS_PATH,
 } from './mirror-contract.ts'
 import type { CoremateTaskState } from './phone-task.ts'
 import type { BrowserInstallStatus } from './browser.ts'
@@ -27,6 +28,13 @@ interface BrowserInstallControl {
   approveInstall(): boolean
   declineInstall(): boolean
   enableInstallPrompt(): () => void
+}
+
+interface PluginUpdateControl {
+  start(): void
+  status(): unknown
+  check(force?: boolean): Promise<void>
+  requestUpdate(): boolean
 }
 
 function sendJson(response: ServerResponse, status: number, value: unknown): void {
@@ -111,6 +119,7 @@ export function installMirrorHttp(
   fleet: DeviceFleet,
   coremateTasks: CoremateTaskControl,
   browser: BrowserInstallControl,
+  updater: PluginUpdateControl,
   preview: PhonePreview,
   streams: ScrcpyVideoStreams,
 ): void {
@@ -118,6 +127,7 @@ export function installMirrorHttp(
     httpCtx.effect(() => {
       const disposers: Array<() => void> = []
       disposers.push(browser.enableInstallPrompt())
+      updater.start()
       const signal = (): AbortSignal => AbortSignal.timeout(5_000)
       const status = async (snapshot?: DeviceFleetSnapshot) => {
         const task = coremateTasks.state()
@@ -135,8 +145,10 @@ export function installMirrorHttp(
             if (request.method !== 'GET') return sendJson(response, 405, { error: 'method_not_allowed' })
             try {
               sendJson(response, 200, await status())
-            } catch {
-              sendJson(response, 503, { error: 'device_discovery_failed' })
+            } catch (error) {
+              sendJson(response, 503, {
+                error: error instanceof Error ? error.message : '手机检测服务暂时不可用，请稍后重试。',
+              })
             }
           },
         }))
@@ -230,6 +242,36 @@ export function installMirrorHttp(
             if (!browser.declineInstall()) return sendJson(response, 409, { error: 'no_browser_installation_waiting' })
             coremateTasks.cancel()
             sendJson(response, 202, { accepted: true })
+          },
+        }))
+        disposers.push(httpCtx.webServer.register({
+          kind: 'exact',
+          path: PLUGIN_UPDATE_STATUS_PATH,
+          handler(request, response) {
+            if (request.method !== 'GET') return sendJson(response, 405, { error: 'method_not_allowed' })
+            if (!sameOriginRead(request)) return sendJson(response, 403, { error: 'same_origin_required' })
+            sendJson(response, 200, updater.status())
+          },
+        }))
+        disposers.push(httpCtx.webServer.register({
+          kind: 'exact',
+          path: PLUGIN_UPDATE_CHECK_PATH,
+          handler(request, response) {
+            if (request.method !== 'POST') return sendJson(response, 405, { error: 'method_not_allowed' })
+            if (!sameOriginMutation(request)) return sendJson(response, 403, { error: 'same_origin_required' })
+            void updater.check(true)
+            sendJson(response, 202, updater.status())
+          },
+        }))
+        disposers.push(httpCtx.webServer.register({
+          kind: 'exact',
+          path: PLUGIN_UPDATE_INSTALL_PATH,
+          handler(request, response) {
+            if (request.method !== 'POST') return sendJson(response, 405, { error: 'method_not_allowed' })
+            if (!sameOriginMutation(request)) return sendJson(response, 403, { error: 'same_origin_required' })
+            if (coremateTasks.isActive()) return sendJson(response, 409, { error: 'stop_the_active_opengui_task_before_updating' })
+            if (!updater.requestUpdate()) return sendJson(response, 409, { error: 'no_plugin_update_available' })
+            sendJson(response, 202, updater.status())
           },
         }))
         disposers.push(httpCtx.webServer.register({

--- a/deepseek-harness-plugin/src/plugin-update.ts
+++ b/deepseek-harness-plugin/src/plugin-update.ts
@@ -1,0 +1,506 @@
+/** Verified public OpenGUI Release discovery and in-place DSH profile updates. */
+
+import { createHash, randomUUID } from 'node:crypto'
+import { constants, readFileSync } from 'node:fs'
+import type { Dirent } from 'node:fs'
+import { mkdir, open, readFile, readdir, realpath, rename, rm } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawn } from 'node:child_process'
+import type { PluginUpdateStatus } from './mirror-contract.ts'
+
+const PACKAGE_NAME = 'dsh-coremate-mobile'
+const RELEASE_TAG_PREFIX = `${PACKAGE_NAME}-v`
+const GITHUB_REPOSITORY = 'Core-Mate/OpenGUI'
+const RELEASES_API = `https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=100`
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000
+const MAX_METADATA_BYTES = 4 * 1_048_576
+const MAX_CHECKSUM_BYTES = 16_384
+const MAX_ARCHIVE_BYTES = 50 * 1_048_576
+
+interface ReleaseAsset {
+  readonly name: string
+  readonly size: number
+  readonly url: string
+  readonly digest?: string
+}
+
+interface AvailableRelease {
+  readonly version: string
+  readonly url: string
+  readonly archive: ReleaseAsset
+  readonly checksum: ReleaseAsset
+}
+
+interface PluginUpdateManagerOptions {
+  currentVersion?: string
+  cacheDir?: string
+  dshHome?: string
+  packageRoot?: string
+  profile?: string
+  githubToken?: string
+  fetch?: typeof globalThis.fetch
+  now?: () => number
+  install?: (profile: string, archive: string, signal: AbortSignal) => Promise<void>
+}
+
+interface GitHubReleaseResponse {
+  tag_name?: unknown
+  html_url?: unknown
+  draft?: unknown
+  prerelease?: unknown
+  assets?: unknown
+}
+
+interface GitHubReleaseAssetResponse {
+  name?: unknown
+  size?: unknown
+  browser_download_url?: unknown
+  digest?: unknown
+  state?: unknown
+}
+
+function dshHome(): string {
+  const configured = process.env.DSH_HOME?.trim()
+  return configured ? resolve(configured) : join(homedir(), '.dsh')
+}
+
+function packageRoot(): string {
+  return dirname(fileURLToPath(new URL('../package.json', import.meta.url)))
+}
+
+function packageVersion(): string {
+  const manifest = JSON.parse(readFileSync(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8')) as { version?: unknown }
+  if (typeof manifest.version !== 'string') throw new Error('opengui: package version is missing')
+  return manifest.version
+}
+
+interface ParsedVersion {
+  readonly core: readonly [number, number, number]
+  readonly prerelease: readonly string[]
+}
+
+function parseVersion(value: string): ParsedVersion | undefined {
+  const match = /^(?:v)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/u.exec(value.trim())
+  if (match === null) return undefined
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4]?.split('.') ?? [],
+  }
+}
+
+/** Compare semver-compatible release versions without accepting ranges or loose tags. */
+export function comparePluginVersions(left: string, right: string): number {
+  const a = parseVersion(left)
+  const b = parseVersion(right)
+  if (a === undefined || b === undefined) throw new Error('opengui: invalid plugin release version')
+  for (let index = 0; index < 3; index += 1) {
+    const difference = a.core[index]! - b.core[index]!
+    if (difference !== 0) return Math.sign(difference)
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    return a.prerelease.length === b.prerelease.length ? 0 : a.prerelease.length === 0 ? 1 : -1
+  }
+  const count = Math.max(a.prerelease.length, b.prerelease.length)
+  for (let index = 0; index < count; index += 1) {
+    const one = a.prerelease[index]
+    const two = b.prerelease[index]
+    if (one === undefined || two === undefined) return one === two ? 0 : one === undefined ? -1 : 1
+    if (one === two) continue
+    const oneNumeric = /^\d+$/u.test(one)
+    const twoNumeric = /^\d+$/u.test(two)
+    if (oneNumeric && twoNumeric) return Number(one) < Number(two) ? -1 : 1
+    if (oneNumeric !== twoNumeric) return oneNumeric ? -1 : 1
+    return one < two ? -1 : 1
+  }
+  return 0
+}
+
+function validatedHttpsUrl(value: unknown, field: string): string {
+  if (typeof value !== 'string') throw new Error(`opengui: release ${field} is missing`)
+  const parsed = new URL(value)
+  if (parsed.protocol !== 'https:') throw new Error(`opengui: release ${field} must use HTTPS`)
+  return parsed.href
+}
+
+function parseAsset(value: unknown): ReleaseAsset | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const asset = value as GitHubReleaseAssetResponse
+  if (typeof asset.name !== 'string' || typeof asset.size !== 'number' || !Number.isSafeInteger(asset.size) || asset.size <= 0) return undefined
+  if (asset.state !== undefined && asset.state !== 'uploaded') return undefined
+  return {
+    name: asset.name,
+    size: asset.size,
+    url: validatedHttpsUrl(asset.browser_download_url, `asset ${asset.name}`),
+    ...(typeof asset.digest === 'string' ? { digest: asset.digest } : {}),
+  }
+}
+
+function pluginReleaseVersion(value: GitHubReleaseResponse): string | undefined {
+  if (value.draft === true || value.prerelease === true || typeof value.tag_name !== 'string') return undefined
+  if (!value.tag_name.startsWith(RELEASE_TAG_PREFIX)) return undefined
+  const version = value.tag_name.slice(RELEASE_TAG_PREFIX.length)
+  const parsed = parseVersion(version)
+  return parsed !== undefined && parsed.prerelease.length === 0 ? version : undefined
+}
+
+/** Select the highest stable plugin release while ignoring OpenGUI Android releases. */
+export function parseLatestRelease(value: unknown): AvailableRelease {
+  if (!Array.isArray(value)) throw new Error('opengui: GitHub returned invalid release metadata')
+  const releases = value
+    .filter((entry): entry is GitHubReleaseResponse => typeof entry === 'object' && entry !== null)
+    .map(release => ({ release, version: pluginReleaseVersion(release) }))
+    .filter((entry): entry is { release: GitHubReleaseResponse, version: string } => entry.version !== undefined)
+    .sort((left, right) => comparePluginVersions(right.version, left.version))
+  const selected = releases[0]
+  if (selected === undefined) throw new Error('opengui: no stable plugin release was found')
+  const { release, version } = selected
+  const archiveName = `${PACKAGE_NAME}-${version}.tgz`
+  const checksumName = `${archiveName}.sha256`
+  const assets = Array.isArray(release.assets) ? release.assets.map(parseAsset).filter(asset => asset !== undefined) : []
+  const archive = assets.find(asset => asset.name === archiveName)
+  const checksum = assets.find(asset => asset.name === checksumName)
+  if (archive === undefined || checksum === undefined) {
+    throw new Error(`opengui: release ${RELEASE_TAG_PREFIX}${version} is missing its verified installer assets`)
+  }
+  if (archive.size > MAX_ARCHIVE_BYTES || checksum.size > MAX_CHECKSUM_BYTES) {
+    throw new Error(`opengui: release ${RELEASE_TAG_PREFIX}${version} assets exceed the safety limit`)
+  }
+  return {
+    version,
+    url: validatedHttpsUrl(release.html_url, 'page URL'),
+    archive,
+    checksum,
+  }
+}
+
+async function fetchFollowingHttps(
+  fetchImpl: typeof globalThis.fetch,
+  initialUrl: string,
+  signal: AbortSignal,
+  headers?: HeadersInit,
+): Promise<Response> {
+  let url = validatedHttpsUrl(initialUrl, 'download URL')
+  let requestHeaders = headers
+  for (let redirects = 0; redirects <= 5; redirects += 1) {
+    const response = await fetchImpl(url, {
+      signal,
+      redirect: 'manual',
+      ...(requestHeaders === undefined ? {} : { headers: requestHeaders }),
+    })
+    if (![301, 302, 303, 307, 308].includes(response.status)) return response
+    const location = response.headers.get('location')
+    if (location === null || redirects === 5) throw new Error('opengui: release download redirected too many times')
+    const next = new URL(location, url)
+    if (next.protocol !== 'https:') throw new Error('opengui: release download redirected away from HTTPS')
+    if (next.origin !== new URL(url).origin) requestHeaders = undefined
+    url = next.href
+  }
+  throw new Error('opengui: unreachable release redirect state')
+}
+
+async function readBoundedResponse(response: Response, maximum: number): Promise<Buffer> {
+  if (!response.ok || response.body === null) throw new Error(`opengui: release request failed with HTTP ${response.status}`)
+  const header = response.headers.get('content-length')
+  const declared = header === null ? undefined : Number(header)
+  if (declared !== undefined && Number.isFinite(declared) && declared > maximum) throw new Error('opengui: release response exceeds the safety limit')
+  const chunks: Uint8Array[] = []
+  let total = 0
+  const reader = response.body.getReader()
+  while (true) {
+    const next = await reader.read()
+    if (next.done) break
+    total += next.value.byteLength
+    if (total > maximum) throw new Error('opengui: release response exceeds the safety limit')
+    chunks.push(next.value)
+  }
+  return Buffer.concat(chunks)
+}
+
+function checksumFromFile(contents: string, archiveName: string): string {
+  const escaped = archiveName.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+  const match = new RegExp(`^([0-9a-fA-F]{64})[\\t ]+\\*?${escaped}\\r?\\n?$`, 'u').exec(contents)
+  if (match === null) throw new Error('opengui: release checksum file has an unexpected format')
+  return match[1]!.toLowerCase()
+}
+
+async function downloadArchive(
+  fetchImpl: typeof globalThis.fetch,
+  release: AvailableRelease,
+  output: string,
+  expectedSha256: string,
+  signal: AbortSignal,
+  progress: (downloaded: number) => void,
+): Promise<void> {
+  const response = await fetchFollowingHttps(fetchImpl, release.archive.url, signal)
+  if (!response.ok || response.body === null) throw new Error(`opengui: release archive failed with HTTP ${response.status}`)
+  const header = response.headers.get('content-length')
+  const declared = header === null ? undefined : Number(header)
+  if (declared !== undefined && Number.isFinite(declared) && declared !== release.archive.size) {
+    throw new Error('opengui: release archive size differs from GitHub metadata')
+  }
+  const file = await open(output, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY, 0o600)
+  const digest = createHash('sha256')
+  let downloaded = 0
+  try {
+    const reader = response.body.getReader()
+    while (true) {
+      signal.throwIfAborted()
+      const next = await reader.read()
+      if (next.done) break
+      downloaded += next.value.byteLength
+      if (downloaded > release.archive.size || downloaded > MAX_ARCHIVE_BYTES) {
+        throw new Error('opengui: release archive exceeded the declared size')
+      }
+      digest.update(next.value)
+      let offset = 0
+      while (offset < next.value.byteLength) {
+        const { bytesWritten } = await file.write(next.value, offset, next.value.byteLength - offset, null)
+        if (bytesWritten === 0) throw new Error('opengui: release archive write made no progress')
+        offset += bytesWritten
+      }
+      progress(downloaded)
+    }
+  } finally {
+    await file.close()
+  }
+  if (downloaded !== release.archive.size) throw new Error('opengui: release archive size mismatch')
+  const actual = digest.digest('hex')
+  if (actual !== expectedSha256) throw new Error('opengui: release archive checksum mismatch')
+  if (release.archive.digest !== undefined && release.archive.digest !== `sha256:${actual}`) {
+    throw new Error('opengui: release archive digest differs from GitHub metadata')
+  }
+}
+
+async function matchingProfiles(home: string, currentPackageRoot: string): Promise<{ exact: string[], candidates: string[] }> {
+  const profilesRoot = join(home, 'profiles')
+  const exact: string[] = []
+  const candidates: string[] = []
+  let entries: Dirent[]
+  try {
+    entries = await readdir(profilesRoot, { withFileTypes: true })
+  } catch {
+    return { exact, candidates }
+  }
+  const resolvedCurrent = await realpath(currentPackageRoot).catch(() => resolve(currentPackageRoot))
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const profileDir = join(profilesRoot, entry.name)
+    try {
+      const manifest = JSON.parse(await readFile(join(profileDir, 'package.json'), 'utf8')) as {
+        dependencies?: Record<string, unknown>
+        dsh?: { profile?: { bundles?: unknown } }
+      }
+      if (typeof manifest.dependencies?.[PACKAGE_NAME] !== 'string') continue
+      if (!Array.isArray(manifest.dsh?.profile?.bundles) || !manifest.dsh.profile.bundles.includes(PACKAGE_NAME)) continue
+      candidates.push(entry.name)
+      const installedRoot = await realpath(join(profileDir, 'node_modules', PACKAGE_NAME))
+      if (installedRoot === resolvedCurrent) exact.push(entry.name)
+    } catch {
+      // A partially installed or unrelated profile is not a safe update target.
+    }
+  }
+  return { exact, candidates }
+}
+
+async function verifyInstalledRelease(home: string, profile: string, version: string): Promise<void> {
+  const profileDir = join(home, 'profiles', profile)
+  const [profileRaw, installedRaw] = await Promise.all([
+    readFile(join(profileDir, 'package.json'), 'utf8'),
+    readFile(join(profileDir, 'node_modules', PACKAGE_NAME, 'package.json'), 'utf8'),
+  ])
+  const manifest = JSON.parse(profileRaw) as {
+    dependencies?: Record<string, unknown>
+    dsh?: { profile?: { bundles?: unknown } }
+  }
+  const installed = JSON.parse(installedRaw) as { version?: unknown }
+  if (typeof manifest.dependencies?.[PACKAGE_NAME] !== 'string'
+    || !Array.isArray(manifest.dsh?.profile?.bundles)
+    || !manifest.dsh.profile.bundles.includes(PACKAGE_NAME)
+    || installed.version !== version) {
+    throw new Error('opengui: DSH reported success but the installed plugin version could not be verified')
+  }
+}
+
+export async function resolveCurrentProfile(home: string, currentPackageRoot: string, configured?: string): Promise<string> {
+  const requested = configured?.trim() || process.env.COREMATE_MOBILE_PROFILE?.trim()
+  const matches = await matchingProfiles(home, currentPackageRoot)
+  if (requested !== undefined && requested !== '') {
+    if (!matches.candidates.includes(requested)) throw new Error(`opengui: configured update profile ${requested} does not contain this plugin`)
+    return requested
+  }
+  if (matches.exact.length === 1) return matches.exact[0]!
+  if (matches.exact.length > 1) throw new Error('opengui: this plugin is linked into multiple DSH profiles; set COREMATE_MOBILE_PROFILE before updating')
+  if (matches.candidates.length === 1) return matches.candidates[0]!
+  if (matches.candidates.length === 0) throw new Error('opengui: could not find the DSH profile that owns this plugin')
+  throw new Error('opengui: multiple DSH profiles contain this plugin; set COREMATE_MOBILE_PROFILE before updating')
+}
+
+function defaultInstall(profile: string, archive: string, signal: AbortSignal): Promise<void> {
+  const launcher = process.argv[1]
+  const nodeRuntime = /^node(?:\.exe)?$/iu.test(basename(process.execPath))
+  if (nodeRuntime && launcher === undefined) return Promise.reject(new Error('opengui: could not locate the current DSH launcher'))
+  const invocation = ['plugin', '--profile', profile, 'add', '--save-exact', archive]
+  const args = nodeRuntime ? [launcher!, ...invocation] : invocation
+  return new Promise((resolveInstall, rejectInstall) => {
+    const child = spawn(process.execPath, args, {
+      env: { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: '0' },
+      shell: false,
+      signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    const collect = (chunk: Buffer): void => { output = `${output}${chunk.toString('utf8')}`.slice(-16_384) }
+    child.stdout?.on('data', collect)
+    child.stderr?.on('data', collect)
+    child.once('error', rejectInstall)
+    child.once('close', code => {
+      if (code === 0) resolveInstall()
+      else rejectInstall(new Error(`opengui: DSH plugin update failed${output.trim() ? `: ${output.trim()}` : ` with exit code ${String(code)}`}`))
+    })
+  })
+}
+
+/** Owns rate-limited update checks and one user-approved verified installation. */
+export class PluginUpdateManager {
+  private readonly currentVersion: string
+  private readonly cacheDir: string
+  private readonly home: string
+  private readonly currentPackageRoot: string
+  private readonly configuredProfile: string | undefined
+  private readonly fetchImpl: typeof globalThis.fetch
+  private readonly githubToken: string | undefined
+  private readonly now: () => number
+  private readonly installImpl: (profile: string, archive: string, signal: AbortSignal) => Promise<void>
+  private readonly lifetime = new AbortController()
+  private phase: PluginUpdateStatus['phase'] = 'idle'
+  private release: AvailableRelease | undefined
+  private message: string | undefined
+  private downloadedBytes: number | undefined
+  private lastCheckedAt: number | undefined
+  private checking: Promise<void> | undefined
+  private updating: Promise<void> | undefined
+
+  constructor(options: PluginUpdateManagerOptions = {}) {
+    this.currentVersion = options.currentVersion ?? packageVersion()
+    this.home = options.dshHome ?? dshHome()
+    this.cacheDir = options.cacheDir ?? join(this.home, 'cache', 'coremate-mobile', 'releases')
+    this.currentPackageRoot = options.packageRoot ?? packageRoot()
+    this.configuredProfile = options.profile
+    this.fetchImpl = options.fetch ?? globalThis.fetch
+    this.githubToken = options.githubToken?.trim() || process.env.GH_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim()
+    this.now = options.now ?? Date.now
+    this.installImpl = options.install ?? defaultInstall
+  }
+
+  start(): void {
+    void this.check().catch(() => {})
+  }
+
+  status(): PluginUpdateStatus {
+    if (!['downloading', 'verifying', 'installing', 'restart-required'].includes(this.phase)) {
+      void this.check().catch(() => {})
+    }
+    return {
+      phase: this.phase,
+      currentVersion: this.currentVersion,
+      ...(this.release === undefined ? {} : {
+        latestVersion: this.release.version,
+        releaseUrl: this.release.url,
+        totalBytes: this.release.archive.size,
+      }),
+      ...(this.downloadedBytes === undefined ? {} : { downloadedBytes: this.downloadedBytes }),
+      ...(this.lastCheckedAt === undefined ? {} : { checkedAt: new Date(this.lastCheckedAt).toISOString() }),
+      ...(this.message === undefined ? {} : { message: this.message }),
+    }
+  }
+
+  check(force = false): Promise<void> {
+    if (this.checking !== undefined) return this.checking
+    if (this.updating !== undefined) return Promise.resolve()
+    if (!force && this.lastCheckedAt !== undefined && this.now() - this.lastCheckedAt < CHECK_INTERVAL_MS) return Promise.resolve()
+    const operation = this.performCheck()
+    this.checking = operation
+    void operation.finally(() => { if (this.checking === operation) this.checking = undefined }).catch(() => {})
+    return operation
+  }
+
+  requestUpdate(): boolean {
+    if (this.phase !== 'available' || this.release === undefined || this.updating !== undefined) return false
+    const operation = this.performUpdate(this.release)
+    this.updating = operation
+    void operation.finally(() => { if (this.updating === operation) this.updating = undefined }).catch(() => {})
+    return true
+  }
+
+  dispose(): void {
+    this.lifetime.abort(new Error('opengui: plugin update manager disposed'))
+  }
+
+  private async performCheck(): Promise<void> {
+    this.phase = 'checking'
+    this.message = undefined
+    try {
+      const response = await fetchFollowingHttps(this.fetchImpl, RELEASES_API, this.lifetime.signal, this.githubHeaders())
+      const metadata = await readBoundedResponse(response, MAX_METADATA_BYTES)
+      const release = parseLatestRelease(JSON.parse(metadata.toString('utf8')))
+      this.release = release
+      this.lastCheckedAt = this.now()
+      this.phase = comparePluginVersions(release.version, this.currentVersion) > 0 ? 'available' : 'up-to-date'
+    } catch (error) {
+      if (this.lifetime.signal.aborted) return
+      this.lastCheckedAt = this.now()
+      this.phase = 'error'
+      this.message = error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  private async performUpdate(release: AvailableRelease): Promise<void> {
+    const releaseDir = join(this.cacheDir, `v${release.version}`)
+    const archivePath = join(releaseDir, release.archive.name)
+    const temporary = join(releaseDir, `.download-${randomUUID()}.tgz`)
+    this.phase = 'downloading'
+    this.downloadedBytes = 0
+    this.message = undefined
+    try {
+      await mkdir(releaseDir, { recursive: true })
+      const checksumResponse = await fetchFollowingHttps(this.fetchImpl, release.checksum.url, this.lifetime.signal)
+      const checksumBytes = await readBoundedResponse(checksumResponse, MAX_CHECKSUM_BYTES)
+      if (checksumBytes.byteLength !== release.checksum.size) throw new Error('opengui: release checksum size mismatch')
+      const expected = checksumFromFile(checksumBytes.toString('utf8'), release.archive.name)
+      await downloadArchive(
+        this.fetchImpl,
+        release,
+        temporary,
+        expected,
+        this.lifetime.signal,
+        downloaded => { this.downloadedBytes = downloaded },
+      )
+      this.phase = 'verifying'
+      await rm(archivePath, { force: true })
+      await rename(temporary, archivePath)
+      const profile = await resolveCurrentProfile(this.home, this.currentPackageRoot, this.configuredProfile)
+      this.phase = 'installing'
+      await this.installImpl(profile, archivePath, this.lifetime.signal)
+      await verifyInstalledRelease(this.home, profile, release.version)
+      this.phase = 'restart-required'
+      this.message = `OpenGUI v${release.version} 已安装到 ${profile} profile；重启 Harness 后生效。`
+    } catch (error) {
+      if (this.lifetime.signal.aborted) return
+      this.phase = 'error'
+      this.message = error instanceof Error ? error.message : String(error)
+    } finally {
+      await rm(temporary, { force: true }).catch(() => {})
+    }
+  }
+
+  private githubHeaders(): HeadersInit {
+    return {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': `${PACKAGE_NAME}/${this.currentVersion}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      ...(this.githubToken === undefined ? {} : { Authorization: `Bearer ${this.githubToken}` }),
+    }
+  }
+}

--- a/deepseek-harness-plugin/tests/adb.spec.ts
+++ b/deepseek-harness-plugin/tests/adb.spec.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { chmod, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   actionCommand,
+  assertAdbReady,
   normalizePhoneAction,
   ObservationId,
   parseDevices,
@@ -10,7 +14,35 @@ import {
 } from '../src/adb.ts'
 import { Config } from '../src/index.ts'
 
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryRoots.splice(0).map(root => rm(root, { recursive: true, force: true })))
+})
+
 describe('coremate-mobile ADB policy', () => {
+  it.skipIf(process.platform === 'win32')('repairs execute bits stripped from the packaged ADB runtime', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opengui-adb-mode-'))
+    temporaryRoots.push(root)
+    const adb = join(root, 'adb')
+    await writeFile(adb, '#!/bin/sh\nexit 0\n')
+    await chmod(adb, 0o644)
+
+    await expect(assertAdbReady(adb, { repairPermissions: true })).resolves.toBeUndefined()
+    expect((await stat(adb)).mode & 0o111).toBe(0o111)
+  })
+
+  it.skipIf(process.platform === 'win32')('does not change permissions on a user-configured ADB path', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opengui-custom-adb-mode-'))
+    temporaryRoots.push(root)
+    const adb = join(root, 'adb')
+    await writeFile(adb, '#!/bin/sh\nexit 0\n')
+    await chmod(adb, 0o644)
+
+    await expect(assertAdbReady(adb)).rejects.toThrow('configured ADB executable')
+    expect((await stat(adb)).mode & 0o111).toBe(0)
+  })
+
   it('accepts one or more authorized devices and deterministically picks the first serial', () => {
     const devices = parseDevices('List of devices attached\nzed device product:p model:Z\nignored unauthorized usb:1\nalpha device product:p model:A\noffline offline\n')
     expect(selectAuthorizedSerial(devices)).toBe('alpha')

--- a/deepseek-harness-plugin/tests/bundle.spec.ts
+++ b/deepseek-harness-plugin/tests/bundle.spec.ts
@@ -42,11 +42,12 @@ describe('standalone DeepSeek Harness bundle', () => {
   })
 
   it('keeps OpenGUI controls in its view while retaining task stop inside the composer', async () => {
-    const [clientSource, viewSource, noticeSource, promotionSource] = await Promise.all([
+    const [clientSource, viewSource, noticeSource, promotionSource, hostSource] = await Promise.all([
       readFile(new URL('src/client/index.tsx', root), 'utf8'),
       readFile(new URL('src/client/CoremateView.tsx', root), 'utf8'),
       readFile(new URL('src/client/CoremateTaskNotice.tsx', root), 'utf8'),
       readFile(new URL('src/client/CorematePromotionCard.tsx', root), 'utf8'),
+      readFile(new URL('src/index.ts', root), 'utf8'),
     ])
 
     expect(clientSource).not.toContain("'conversation.composer.dock'")
@@ -56,12 +57,16 @@ describe('standalone DeepSeek Harness bundle', () => {
     expect(clientSource).not.toContain("'coremate-mobile-browser-install'")
     expect(clientSource).not.toContain('MirrorButton')
     expect(viewSource).toContain('<BrowserInstallPrompt />')
+    expect(viewSource).toContain('<PluginUpdatePrompt />')
     expect(viewSource).toContain('data-coremate-device-wall')
     expect(viewSource).toContain('data-coremate-connect-more')
     expect(viewSource).toContain('https://opengui.ai/')
     expect(noticeSource).toContain('请前往 OpenGUI Tab')
     expect(promotionSource).toContain('https://github.com/Core-Mate/OpenGUI/blob/main/deepseek-harness-plugin/docs/use-cases.zh.md')
     expect(promotionSource).not.toContain('Coremate-Mobile-Plugin')
+    expect(viewSource).toContain('设备检测异常')
+    expect(viewSource).toContain('正在自动重试')
+    expect(hostSource).toContain('连接完成后点击“重新检测”')
     expect(clientSource).not.toContain("'shell.overlay'")
   })
 

--- a/deepseek-harness-plugin/tests/mirror-button.spec.ts
+++ b/deepseek-harness-plugin/tests/mirror-button.spec.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { readMirrorStatus } from '../src/client/MirrorButton.tsx'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('OpenGUI workbench status errors', () => {
+  it('shows the server diagnostic instead of reducing every failure to HTTP 503', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: 'OpenGUI bundled ADB is missing execute permission.' }),
+      { status: 503, headers: { 'Content-Type': 'application/json' } },
+    )))
+
+    await expect(readMirrorStatus()).rejects.toThrow('bundled ADB is missing execute permission')
+  })
+})

--- a/deepseek-harness-plugin/tests/mirror-http.spec.ts
+++ b/deepseek-harness-plugin/tests/mirror-http.spec.ts
@@ -3,7 +3,8 @@ import type { AddressInfo } from 'node:net'
 import type { Context } from '@deepseek-ai/cordis'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  DEVICE_PREVIEW_PATH, DEVICE_SELECTION_PATH, DEVICE_STREAM_ENABLE_PATH, DEVICE_STREAM_STATUS_PATH, PHONE_TASK_STATUS_PATH,
+  DEVICE_PREVIEW_PATH, DEVICE_SELECTION_PATH, DEVICE_STREAM_ENABLE_PATH, DEVICE_STREAM_STATUS_PATH, MIRROR_STATUS_PATH, PHONE_TASK_STATUS_PATH,
+  PLUGIN_UPDATE_INSTALL_PATH, PLUGIN_UPDATE_STATUS_PATH,
 } from '../src/mirror-contract.ts'
 import { installMirrorHttp, publicStreamError } from '../src/mirror-http.ts'
 
@@ -13,7 +14,7 @@ afterEach(async () => {
   await Promise.all(servers.splice(0).map(server => new Promise<void>(resolve => server.close(() => resolve()))))
 })
 
-async function setup(options: { selectionLocked?: boolean } = {}) {
+async function setup(options: { selectionLocked?: boolean, fleetError?: Error } = {}) {
   const routes = new Map<string, (request: never, response: never) => unknown>()
   const device = { id: 'opaque-device-id', serial: 'adb-serial-must-stay-private', label: 'Pixel 9' }
   const previewRead = vi.fn(async () => ({ data: Buffer.from([0xff, 0xd8, 0xff, 0xd9]), etag: '"preview-etag"' }))
@@ -21,7 +22,10 @@ async function setup(options: { selectionLocked?: boolean } = {}) {
     devices: [{ id: device.id, label: device.label, selected: ids.includes(device.id) }],
   }))
   const fleet = {
-    snapshot: async () => ({ devices: [{ id: device.id, label: device.label, selected: true }] }),
+    snapshot: async () => {
+      if (options.fleetError !== undefined) throw options.fleetError
+      return { devices: [{ id: device.id, label: device.label, selected: true }] }
+    },
     select,
     async resolveConnected(ids: readonly string[]) {
       if (ids.length !== 1 || ids[0] !== device.id) throw new Error('unknown device')
@@ -44,6 +48,13 @@ async function setup(options: { selectionLocked?: boolean } = {}) {
     approveInstall: () => false,
     declineInstall: () => false,
   }
+  const updater = {
+    start: vi.fn(),
+    dispose: vi.fn(),
+    status: vi.fn(() => ({ phase: 'available', currentVersion: '0.1.6', latestVersion: '0.1.7' })),
+    check: vi.fn(async () => {}),
+    requestUpdate: vi.fn(() => true),
+  }
   const httpCtx = {
     webServer: {
       register(definition: { path: string, handler(request: never, response: never): unknown }) {
@@ -63,6 +74,7 @@ async function setup(options: { selectionLocked?: boolean } = {}) {
     fleet as never,
     { isActive: () => state().active, state, cancel: () => false },
     browser as never,
+    updater,
     { read: previewRead } as never,
     { status: async () => ({ supported: true, cached: true, approved: true, phase: 'ready' }), approve: () => true, subscribe: vi.fn() } as never,
   )
@@ -75,10 +87,20 @@ async function setup(options: { selectionLocked?: boolean } = {}) {
   servers.push(server)
   await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
   const address = server.address() as AddressInfo
-  return { base: `http://127.0.0.1:${address.port}`, device, previewRead, select }
+  return { base: `http://127.0.0.1:${address.port}`, device, previewRead, select, updater }
 }
 
 describe('OpenGUI local preview HTTP surface', () => {
+  it('preserves an actionable device-discovery failure for the local workbench', async () => {
+    const failure = new Error('OpenGUI bundled ADB is missing execute permission.')
+    const { base } = await setup({ fleetError: failure })
+
+    const response = await fetch(`${base}${MIRROR_STATUS_PATH}`)
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({ error: failure.message })
+  })
+
   it('keeps the legacy enable route idempotent while reporting automatic readiness', async () => {
     const { base } = await setup()
     const status = await fetch(`${base}${DEVICE_STREAM_STATUS_PATH}`, { headers: { Origin: base } })
@@ -118,6 +140,27 @@ describe('OpenGUI local preview HTTP surface', () => {
     const { base } = await setup()
     expect((await fetch(`${base}${PHONE_TASK_STATUS_PATH}`, { headers: { Origin: base } })).status).toBe(200)
     expect((await fetch(`${base}${PHONE_TASK_STATUS_PATH}`, { headers: { Origin: 'https://evil.example' } })).status).toBe(403)
+  })
+
+  it('exposes update state locally and accepts only same-origin, idle update requests', async () => {
+    const idle = await setup()
+    const status = await fetch(`${idle.base}${PLUGIN_UPDATE_STATUS_PATH}`, { headers: { Origin: idle.base } })
+    expect(status.status).toBe(200)
+    expect(await status.json()).toMatchObject({ phase: 'available', latestVersion: '0.1.7' })
+    expect((await fetch(`${idle.base}${PLUGIN_UPDATE_STATUS_PATH}`, { headers: { Origin: 'https://evil.example' } })).status).toBe(403)
+
+    const accepted = await fetch(`${idle.base}${PLUGIN_UPDATE_INSTALL_PATH}`, {
+      method: 'POST', headers: { Origin: idle.base },
+    })
+    expect(accepted.status).toBe(202)
+    expect(idle.updater.requestUpdate).toHaveBeenCalledOnce()
+
+    const running = await setup({ selectionLocked: true })
+    const blocked = await fetch(`${running.base}${PLUGIN_UPDATE_INSTALL_PATH}`, {
+      method: 'POST', headers: { Origin: running.base },
+    })
+    expect(blocked.status).toBe(409)
+    expect(running.updater.requestUpdate).not.toHaveBeenCalled()
   })
 
   it('allows device selection while waiting and locks it only after routing starts', async () => {

--- a/deepseek-harness-plugin/tests/plugin-update-prompt.spec.ts
+++ b/deepseek-harness-plugin/tests/plugin-update-prompt.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import type { PluginUpdateStatus } from '../src/mirror-contract.ts'
+import { pluginUpdatePresentation } from '../src/client/PluginUpdatePrompt.tsx'
+
+function status(phase: PluginUpdateStatus['phase'], overrides: Partial<PluginUpdateStatus> = {}): PluginUpdateStatus {
+  return { phase, currentVersion: '0.1.6', latestVersion: '0.1.7', ...overrides }
+}
+
+describe('OpenGUI plugin update prompt', () => {
+  it('stays out of the workbench when current or during a background check', () => {
+    expect(pluginUpdatePresentation()).toEqual({ kind: 'hidden' })
+    expect(pluginUpdatePresentation(status('up-to-date'))).toEqual({ kind: 'hidden' })
+    expect(pluginUpdatePresentation(status('checking'))).toEqual({ kind: 'hidden' })
+  })
+
+  it('offers an available release and reports bounded progress', () => {
+    expect(pluginUpdatePresentation(status('available'))).toEqual({ kind: 'available', title: 'OpenGUI v0.1.7 可用' })
+    expect(pluginUpdatePresentation(status('downloading', { downloadedBytes: 40, totalBytes: 100 }), true)).toEqual({
+      kind: 'progress', title: '正在下载 OpenGUI 更新：40%', percent: 40,
+    })
+    expect(pluginUpdatePresentation(status('verifying'), true)).toEqual({ kind: 'progress', title: '正在校验 OpenGUI 更新…' })
+    expect(pluginUpdatePresentation(status('installing'), true)).toEqual({ kind: 'progress', title: '正在安装 OpenGUI 更新…' })
+  })
+
+  it('keeps restart and user-triggered failures visible', () => {
+    expect(pluginUpdatePresentation(status('restart-required'))).toEqual({ kind: 'restart', title: 'OpenGUI v0.1.7 已安装' })
+    expect(pluginUpdatePresentation(status('error', { message: 'checksum mismatch' }))).toEqual({ kind: 'hidden' })
+    expect(pluginUpdatePresentation(status('error', { message: 'checksum mismatch' }), true)).toEqual({
+      kind: 'error', title: 'checksum mismatch',
+    })
+  })
+})

--- a/deepseek-harness-plugin/tests/plugin-update.spec.ts
+++ b/deepseek-harness-plugin/tests/plugin-update.spec.ts
@@ -1,0 +1,170 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  comparePluginVersions,
+  parseLatestRelease,
+  PluginUpdateManager,
+  resolveCurrentProfile,
+} from '../src/plugin-update.ts'
+
+const temporary: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporary.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+async function home(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), 'opengui-update-test-'))
+  temporary.push(path)
+  return path
+}
+
+function pluginRelease(version: string, archive: Buffer, checksum: Buffer): Record<string, unknown> {
+  const tag = `dsh-coremate-mobile-v${version}`
+  const base = `https://github.com/Core-Mate/OpenGUI/releases/download/${tag}`
+  const archiveName = `dsh-coremate-mobile-${version}.tgz`
+  return {
+    tag_name: tag,
+    html_url: `https://github.com/Core-Mate/OpenGUI/releases/tag/${tag}`,
+    draft: false,
+    prerelease: false,
+    assets: [
+      {
+        name: archiveName,
+        size: archive.byteLength,
+        state: 'uploaded',
+        url: `https://api.github.com/repos/Core-Mate/OpenGUI/releases/assets/${archiveName}`,
+        browser_download_url: `${base}/${archiveName}`,
+        digest: `sha256:${createHash('sha256').update(archive).digest('hex')}`,
+      },
+      {
+        name: `${archiveName}.sha256`,
+        size: checksum.byteLength,
+        state: 'uploaded',
+        url: `https://api.github.com/repos/Core-Mate/OpenGUI/releases/assets/${archiveName}.sha256`,
+        browser_download_url: `${base}/${archiveName}.sha256`,
+      },
+    ],
+  }
+}
+
+function androidRelease(): Record<string, unknown> {
+  return {
+    tag_name: 'v9.9.9',
+    html_url: 'https://github.com/Core-Mate/OpenGUI/releases/tag/v9.9.9',
+    draft: false,
+    prerelease: false,
+    assets: [{ name: 'OpenGUI-Android-v9.9.9.apk', size: 123, state: 'uploaded', url: 'https://api.github.com/android' }],
+  }
+}
+
+function releaseFetch(metadata: readonly Record<string, unknown>[], archive: Buffer, checksum: Buffer): typeof fetch {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = String(input)
+    if (url.includes('/releases?per_page=100')) return new Response(JSON.stringify(metadata))
+    if (url.endsWith('.sha256')) return new Response(checksum, { headers: { 'Content-Length': String(checksum.byteLength) } })
+    if (url.endsWith('.tgz')) return new Response(archive, { headers: { 'Content-Length': String(archive.byteLength) } })
+    return new Response('not found', { status: 404 })
+  }) as typeof fetch
+}
+
+async function writeProfile(root: string, name: string): Promise<void> {
+  const profile = join(root, 'profiles', name)
+  await mkdir(profile, { recursive: true })
+  await writeFile(join(profile, 'package.json'), JSON.stringify({
+    dependencies: { 'dsh-coremate-mobile': 'file:release.tgz' },
+    dsh: { profile: { bundles: ['dsh-coremate-mobile'] } },
+  }))
+}
+
+describe('OpenGUI plugin release updater', () => {
+  it('compares stable and prerelease semantic versions', () => {
+    expect(comparePluginVersions('0.1.7', '0.1.6')).toBe(1)
+    expect(comparePluginVersions('v1.0.0', '1.0.0-rc.2')).toBe(1)
+    expect(comparePluginVersions('1.0.0-rc.2', '1.0.0-rc.10')).toBe(-1)
+    expect(comparePluginVersions('1.2.3+build.2', '1.2.3+build.1')).toBe(0)
+  })
+
+  it('selects the highest stable plugin release and ignores newer Android releases', () => {
+    const archive = Buffer.from('archive')
+    const checksum = Buffer.from(`${createHash('sha256').update(archive).digest('hex')}  dsh-coremate-mobile-0.1.7.tgz\n`)
+    expect(parseLatestRelease([
+      androidRelease(),
+      pluginRelease('0.1.6', archive, checksum),
+      pluginRelease('0.1.7', archive, checksum),
+    ])).toMatchObject({
+      version: '0.1.7',
+      archive: { name: 'dsh-coremate-mobile-0.1.7.tgz' },
+      checksum: { name: 'dsh-coremate-mobile-0.1.7.tgz.sha256' },
+    })
+  })
+
+  it('requires the versioned package and checksum assets', () => {
+    expect(() => parseLatestRelease([{ ...pluginRelease('0.1.7', Buffer.from('x'), Buffer.from('y')), assets: [] }]))
+      .toThrow('verified installer assets')
+  })
+
+  it('checks, verifies, caches, and installs an available public release into the owning profile', async () => {
+    const root = await home()
+    await writeProfile(root, 'web')
+    const archive = Buffer.from('verified plugin package')
+    const digest = createHash('sha256').update(archive).digest('hex')
+    const archiveName = 'dsh-coremate-mobile-0.1.7.tgz'
+    const checksum = Buffer.from(`${digest}  ${archiveName}\n`)
+    const install = vi.fn(async (_profile: string, path: string) => {
+      expect(await readFile(path)).toEqual(archive)
+      const installed = join(root, 'profiles', 'web', 'node_modules', 'dsh-coremate-mobile')
+      await mkdir(installed, { recursive: true })
+      await writeFile(join(installed, 'package.json'), JSON.stringify({ version: '0.1.7' }))
+    })
+    const fetchImpl = releaseFetch([androidRelease(), pluginRelease('0.1.7', archive, checksum)], archive, checksum)
+    const manager = new PluginUpdateManager({
+      currentVersion: '0.1.6',
+      dshHome: root,
+      packageRoot: join(root, 'source-package'),
+      fetch: fetchImpl,
+      install,
+    })
+
+    await manager.check()
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringContaining('/repos/Core-Mate/OpenGUI/releases?per_page=100'),
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: 'application/vnd.github+json' }) }),
+    )
+    expect(manager.status()).toMatchObject({ phase: 'available', currentVersion: '0.1.6', latestVersion: '0.1.7' })
+    expect(manager.requestUpdate()).toBe(true)
+    await vi.waitFor(() => { expect(manager.status().phase).toBe('restart-required') })
+    expect(install).toHaveBeenCalledWith(
+      'web',
+      join(root, 'cache', 'coremate-mobile', 'releases', 'v0.1.7', archiveName),
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('does not install an archive whose checksum does not match', async () => {
+    const root = await home()
+    await writeProfile(root, 'web')
+    const archive = Buffer.from('tampered')
+    const checksum = Buffer.from(`${'0'.repeat(64)}  dsh-coremate-mobile-0.1.7.tgz\n`)
+    const install = vi.fn(async () => {})
+    const manager = new PluginUpdateManager({
+      currentVersion: '0.1.6', dshHome: root, packageRoot: root,
+      fetch: releaseFetch([pluginRelease('0.1.7', archive, checksum)], archive, checksum), install,
+    })
+    await manager.check()
+    expect(manager.requestUpdate()).toBe(true)
+    await vi.waitFor(() => { expect(manager.status().phase).toBe('error') })
+    expect(manager.status().message).toContain('checksum mismatch')
+    expect(install).not.toHaveBeenCalled()
+  })
+
+  it('refuses to guess when multiple profiles contain non-identical installations', async () => {
+    const root = await home()
+    await Promise.all([writeProfile(root, 'web'), writeProfile(root, 'custom')])
+    await expect(resolveCurrentProfile(root, join(root, 'source-package'))).rejects.toThrow('multiple DSH profiles')
+    await expect(resolveCurrentProfile(root, join(root, 'source-package'), 'custom')).resolves.toBe('custom')
+  })
+})


### PR DESCRIPTION
## Summary
- self-heal execute bits only for the bundled ADB on DSH and Codex hosts
- preserve actionable device-discovery diagnostics and retry them in the workbench
- check public OpenGUI namespaced plugin Releases, ignoring APK/draft/prerelease entries
- add verified, idle-only in-product update installation and release notes

## Verification
- 42 test files / 228 tests passed
- build and Codex plugin validation passed
- npm package retains macOS/Linux ADB mode 755
- extracted ADB self-heal verified from 644 to 755
- live public GitHub Releases API selects dsh-coremate-mobile v0.1.6 and ignores Android Releases