### PR TITLE
fix(plugin): make checkout auto-reload safe

### DIFF
--- a/deepseek-harness-plugin/scripts/dev-auto-reload.mjs
+++ b/deepseek-harness-plugin/scripts/dev-auto-reload.mjs
@@ -55,8 +55,14 @@ async function installHook(ifLinked) {
 
 async function changedFiles() {
   try {
-    const { stdout } = await run('git', ['diff', '--name-only', 'ORIG_HEAD..HEAD'])
-    return stdout.split(/\r?\n/u).filter(Boolean)
+    const [{ stdout }, { stdout: prefixOutput }] = await Promise.all([
+      run('git', ['diff', '--name-only', 'ORIG_HEAD..HEAD']),
+      run('git', ['rev-parse', '--show-prefix']),
+    ])
+    const prefix = prefixOutput.trim()
+    return stdout.split(/\r?\n/u).filter(Boolean).map(path => (
+      prefix !== '' && path.startsWith(prefix) ? path.slice(prefix.length) : path
+    ))
   } catch {
     return ['src/unknown']
   }
@@ -126,7 +132,7 @@ async function launchdLabel() {
     const rows = (await exec('launchctl', ['list'])).stdout.split(/\r?\n/u)
     for (const row of rows) {
       const match = /^\s*(\d+)\s+\S+\s+(\S+)\s*$/u.exec(row)
-      if (match && ancestors.has(match[1])) return match[2]
+      if (match && ancestors.has(match[1]) && !match[2].startsWith('application.')) return match[2]
     }
   } catch { /* unmanaged processes are left untouched */ }
   return undefined

--- a/deepseek-harness-plugin/tests/dev-auto-reload.spec.ts
+++ b/deepseek-harness-plugin/tests/dev-auto-reload.spec.ts
@@ -59,7 +59,7 @@ describe('linked-checkout auto reload', () => {
     const calls = join(value.root, 'calls.log')
     await writeFile(join(value.bin, 'pnpm'), `#!/usr/bin/env bash\nprintf 'pnpm %s\\n' "$*" >> "${calls}"\n`)
     await writeFile(join(value.bin, 'launchctl'), `#!/usr/bin/env bash\nprintf 'launchctl %s\\n' "$*" >> "${calls}"\n`)
-    await writeFile(join(value.bin, 'git'), `#!/usr/bin/env bash\nif [[ "$1" == "diff" ]]; then printf 'src/index.ts\\n'; exit 0; fi\nif [[ "$1" == "rev-parse" ]]; then printf 'abc1234\\n'; exit 0; fi\nexit 1\n`)
+    await writeFile(join(value.bin, 'git'), `#!/usr/bin/env bash\nif [[ "$1" == "diff" ]]; then printf 'deepseek-harness-plugin/src/index.ts\\n'; exit 0; fi\nif [[ "$1" == "rev-parse" && "$2" == "--show-prefix" ]]; then printf 'deepseek-harness-plugin/\\n'; exit 0; fi\nif [[ "$1" == "rev-parse" ]]; then printf 'abc1234\\n'; exit 0; fi\nexit 1\n`)
     await Promise.all(['pnpm', 'launchctl', 'git'].map(name => chmod(join(value.bin, name), 0o755)))
 
     const server = createServer((request, response) => {
@@ -96,5 +96,44 @@ describe('linked-checkout auto reload', () => {
     const log = await readFile(calls, 'utf8')
     expect(log).toContain('pnpm run build')
     expect(log).toContain(`launchctl kickstart -k gui/${process.getuid?.() ?? 0}/com.example.opengui`)
+  })
+
+  it('does not restart a desktop application ancestor as though it were a DSH service', async () => {
+    const value = await fixture()
+    const calls = join(value.root, 'calls.log')
+    await writeFile(join(value.bin, 'pnpm'), `#!/usr/bin/env bash\nprintf 'pnpm %s\\n' "$*" >> "${calls}"\n`)
+    await writeFile(join(value.bin, 'lsof'), '#!/usr/bin/env bash\nprintf \'321\\n\'\n')
+    await writeFile(join(value.bin, 'ps'), '#!/usr/bin/env bash\nprintf \'123\\n\'\n')
+    await writeFile(join(value.bin, 'launchctl'), `#!/usr/bin/env bash\nprintf '123\\t0\\tapplication.com.example.desktop.1\\n'\n`)
+    await writeFile(join(value.bin, 'git'), `#!/usr/bin/env bash\nif [[ "$1" == "diff" ]]; then printf 'deepseek-harness-plugin/src/index.ts\\n'; exit 0; fi\nif [[ "$1" == "rev-parse" && "$2" == "--show-prefix" ]]; then printf 'deepseek-harness-plugin/\\n'; exit 0; fi\nif [[ "$1" == "rev-parse" ]]; then printf 'abc1234\\n'; exit 0; fi\nexit 1\n`)
+    await Promise.all(['pnpm', 'lsof', 'ps', 'launchctl', 'git'].map(name => chmod(join(value.bin, name), 0o755)))
+
+    const server = createServer((request, response) => {
+      if (request.url === '/coremate-mobile/task/status') {
+        response.setHeader('content-type', 'application/json')
+        response.end(JSON.stringify({ active: false }))
+      } else {
+        response.end('<script>window.__DSH_BOOT__={}</script>')
+      }
+    })
+    servers.push(server)
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address()
+    if (address === null || typeof address === 'string') throw new Error('missing test server port')
+
+    const { stdout } = await exec(process.execPath, [updater.pathname, 'after-pull'], {
+      cwd: value.repo,
+      env: {
+        ...process.env,
+        PATH: `${value.bin}:${process.env.PATH ?? ''}`,
+        DSH_HOME: value.dshHome,
+        OPENGUI_AUTO_RELOAD_REPO_ROOT: value.repo,
+        OPENGUI_AUTO_RELOAD_PORT: String(address.port),
+        OPENGUI_AUTO_RELOAD_NO_OPEN: '1',
+      },
+    })
+
+    expect(await readFile(calls, 'utf8')).toContain('pnpm run build')
+    expect(stdout).toContain('not launchd-managed')
   })
 })


### PR DESCRIPTION
## Summary
- normalize pull diff paths when the plugin lives in the public monorepo
- avoid treating a desktop `application.*` launchd entry as a managed DSH background service
- add regression coverage for both cases

## Verification
- `pnpm run check`
- 42 test files / 229 tests passed
- host/client/Codex bundles built and validated