### PR TITLE
fix(plugin): install monorepo hook at Git path

### DIFF
--- a/deepseek-harness-plugin/.githooks/post-merge
+++ b/deepseek-harness-plugin/.githooks/post-merge
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(git rev-parse --show-toplevel)"
-exec node "${repo_root}/scripts/dev-auto-reload.mjs" after-pull
+hook_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+plugin_root="$(cd "${hook_dir}/.." && pwd)"
+exec node "${plugin_root}/scripts/dev-auto-reload.mjs" after-pull

--- a/deepseek-harness-plugin/scripts/dev-auto-reload.mjs
+++ b/deepseek-harness-plugin/scripts/dev-auto-reload.mjs
@@ -49,7 +49,8 @@ async function installHook(ifLinked) {
     throw new Error(`DSH profile ${profile} is not linked to ${repoRoot}`)
   }
   await chmod(hookPath, 0o755)
-  await run('git', ['config', 'core.hooksPath', '.githooks'])
+  const prefix = (await run('git', ['rev-parse', '--show-prefix'])).stdout.trim()
+  await run('git', ['config', 'core.hooksPath', `${prefix}.githooks`])
   log('installed the repository post-merge hook; future pulls will build and reload automatically')
 }
 

--- a/deepseek-harness-plugin/tests/dev-auto-reload.spec.ts
+++ b/deepseek-harness-plugin/tests/dev-auto-reload.spec.ts
@@ -1,5 +1,5 @@
 import { createServer } from 'node:http'
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFile } from 'node:child_process'
@@ -16,10 +16,11 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })))
 })
 
-async function fixture(linked = true) {
+async function fixture(linked = true, monorepo = false) {
   const root = await mkdtemp(join(tmpdir(), 'opengui-auto-reload-'))
   roots.push(root)
-  const repo = join(root, 'repo')
+  const gitRoot = join(root, 'repo')
+  const repo = monorepo ? join(gitRoot, 'deepseek-harness-plugin') : gitRoot
   const dshHome = join(root, 'dsh-home')
   const profile = join(dshHome, 'profiles', 'web')
   const bin = join(root, 'bin')
@@ -32,19 +33,23 @@ async function fixture(linked = true) {
   await writeFile(join(profile, 'package.json'), JSON.stringify({
     dependencies: { 'dsh-coremate-mobile': linked ? `link:${repo}` : 'file:/tmp/release.tgz' },
   }))
-  await exec('git', ['init', '-q'], { cwd: repo })
-  return { root, repo, dshHome, bin }
+  await exec('git', ['init', '-q'], { cwd: gitRoot })
+  return { root, repo, gitRoot, dshHome, bin }
 }
 
 describe('linked-checkout auto reload', () => {
   it('installs the versioned post-merge hook only for the linked DSH profile', async () => {
-    const value = await fixture()
+    const value = await fixture(true, true)
     await exec(process.execPath, [updater.pathname, 'install'], {
       cwd: value.repo,
       env: { ...process.env, OPENGUI_AUTO_RELOAD_REPO_ROOT: value.repo, DSH_HOME: value.dshHome },
     })
     const { stdout } = await exec('git', ['config', '--get', 'core.hooksPath'], { cwd: value.repo })
-    expect(stdout.trim()).toBe('.githooks')
+    expect(stdout.trim()).toBe('deepseek-harness-plugin/.githooks')
+    const { stdout: resolvedHooks } = await exec('git', [
+      'rev-parse', '--path-format=absolute', '--git-path', 'hooks',
+    ], { cwd: value.gitRoot })
+    expect(await realpath(resolvedHooks.trim())).toBe(await realpath(join(value.repo, '.githooks')))
 
     const packaged = await fixture(false)
     await exec(process.execPath, [updater.pathname, 'install', '--if-linked'], {


### PR DESCRIPTION
## Summary
- configure the post-merge hook relative to the public monorepo root
- resolve the plugin root from the hook location instead of assuming the Git root is the plugin root
- cover real monorepo hook-path resolution

## Verification
- `pnpm run check`
- 42 test files / 229 tests passed
- host/client/Codex bundles built and validated