### PR TITLE
ci(plugin): allow VicarDa to publish releases

### DIFF
--- a/.github/workflows/deepseek-harness-plugin-release.yml
+++ b/.github/workflows/deepseek-harness-plugin-release.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.actor == 'HarveySang'
+    if: github.actor == 'HarveySang' || github.actor == 'VicarDa'
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
## Summary
- allow both `HarveySang` and `VicarDa` to trigger the plugin release job
- leave source ancestry, version, checksum, package, and release validation unchanged

## Verification
- workflow YAML parses successfully
- no release tag has been created